### PR TITLE
update sdk + fix reconnect bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,983 @@
+# Meta Wearables DAT SDK
+
+> Full API reference: https://wearables.developer.meta.com/llms.txt?full=true
+> Developer docs: https://wearables.developer.meta.com/docs/develop/
+
+## Code style
+
+
+## Architecture
+
+The SDK is organized into three modules:
+- **MWDATCore**: Device discovery, registration, permissions, device selectors
+- **MWDATCamera**: StreamSession, VideoFrame, photo capture
+- **MWDATMockDevice**: MockDeviceKit for testing without hardware
+
+## Swift Patterns
+
+- Use `async/await` for all SDK operations — the SDK is fully async
+- Use `AsyncSequence` / publisher `.listen {}` for observing streams
+- Annotate UI-updating code with `@MainActor`
+- Never block the main thread with frame processing
+- Handle errors with do/catch — the SDK throws typed errors
+
+## Naming Conventions
+
+| Type | Convention | Example |
+|------|-----------|---------|
+| Entry point | `Wearables.shared` | `Wearables.shared.startRegistration()` |
+| Sessions | `*Session` | `StreamSession`, `DeviceStateSession` |
+| Selectors | `*DeviceSelector` | `AutoDeviceSelector`, `SpecificDeviceSelector` |
+| Config | `*Config` | `StreamSessionConfig` |
+| Publishers | `*Publisher` | `statePublisher`, `videoFramePublisher` |
+
+## Imports
+
+```swift
+import MWDATCore    // Registration, devices, permissions
+import MWDATCamera  // StreamSession, VideoFrame, photo capture
+```
+
+For testing:
+```swift
+import MWDATMockDevice  // MockDeviceKit, MockRaybanMeta, MockCameraKit
+```
+
+## Key Types
+
+- `Wearables` — SDK entry point. Call `Wearables.configure()` at launch, then use `Wearables.shared`
+- `StreamSession` — Camera streaming session. Create with config + device selector
+- `VideoFrame` — Individual video frame with `.makeUIImage()` convenience
+- `AutoDeviceSelector` — Automatically selects the best available device
+- `SpecificDeviceSelector` — Selects a specific device by identifier
+- `StreamSessionConfig` — Configure video codec, resolution, frame rate
+- `MockDeviceKit` — Factory for creating simulated devices in tests
+
+## Error Handling
+
+```swift
+do {
+    try Wearables.configure()
+} catch {
+    // Handle configuration error
+}
+
+do {
+    try Wearables.shared.startRegistration()
+} catch {
+    // Handle registration error
+}
+```
+
+## Links
+
+- [iOS API Reference](https://wearables.developer.meta.com/docs/reference/ios_swift/dat/0.5)
+- [Developer Documentation](https://wearables.developer.meta.com/docs/develop/)
+- [GitHub Repository](https://github.com/facebook/meta-wearables-dat-ios)
+
+## Dev environment tips
+
+
+Guide for setting up the Meta Wearables Device Access Toolkit in an iOS app.
+
+## Prerequisites
+
+- Xcode 15.0+, iOS 16.0+ deployment target
+- Meta AI companion app installed on test device
+- Ray-Ban Meta glasses or Meta Ray-Ban Display glasses (or use MockDeviceKit for development)
+- Developer Mode enabled in Meta AI app (Settings > Your glasses > Developer Mode)
+
+## Step 1: Add the SDK via Swift Package Manager
+
+1. In Xcode, select **File** > **Add Package Dependencies...**
+2. Enter `https://github.com/facebook/meta-wearables-dat-ios`
+3. Select a [version](https://github.com/facebook/meta-wearables-dat-ios/tags)
+4. Add `MWDATCore` and `MWDATCamera` to your target
+
+## Step 2: Configure Info.plist
+
+Add these required entries to your `Info.plist`:
+
+```xml
+<!-- URL scheme for Meta AI callbacks -->
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myexampleapp</string>
+    </array>
+  </dict>
+</array>
+
+<!-- Allow Meta AI to callback -->
+<key>LSApplicationQueriesSchemes</key>
+<array>
+  <string>fb-viewapp</string>
+</array>
+
+<!-- External accessory protocol -->
+<key>UISupportedExternalAccessoryProtocols</key>
+<array>
+  <string>com.meta.ar.wearable</string>
+</array>
+
+<!-- Background modes -->
+<key>UIBackgroundModes</key>
+<array>
+  <string>bluetooth-peripheral</string>
+  <string>external-accessory</string>
+</array>
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>Needed to connect to Meta Wearables</string>
+
+<!-- DAT configuration -->
+<key>MWDAT</key>
+<dict>
+  <key>AppLinkURLScheme</key>
+  <string>myexampleapp://</string>
+  <key>MetaAppID</key>
+  <string>0</string>
+</dict>
+```
+
+Replace `myexampleapp` with your app's URL scheme. Use `0` for `MetaAppID` during development with Developer Mode.
+
+## Step 3: Initialize the SDK
+
+Call `Wearables.configure()` once at app launch:
+
+```swift
+import MWDATCore
+
+@main
+struct MyApp: App {
+    init() {
+        do {
+            try Wearables.configure()
+        } catch {
+            assertionFailure("Failed to configure Wearables SDK: \(error)")
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
+
+## Step 4: Handle URL callbacks
+
+Your app must handle the URL callback from Meta AI after registration:
+
+```swift
+.onOpenURL { url in
+    Task {
+        _ = try? await Wearables.shared.handleUrl(url)
+    }
+}
+```
+
+## Step 5: Register with Meta AI
+
+```swift
+func startRegistration() throws {
+    try Wearables.shared.startRegistration()
+}
+```
+
+Observe registration state:
+
+```swift
+Task {
+    for await state in Wearables.shared.registrationStateStream() {
+        // Update UI based on registration state
+    }
+}
+```
+
+## Step 6: Start streaming
+
+```swift
+import MWDATCamera
+
+let deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
+let config = StreamSessionConfig(
+    videoCodec: .raw,
+    resolution: .low,
+    frameRate: 24
+)
+let session = StreamSession(streamSessionConfig: config, deviceSelector: deviceSelector)
+
+// Observe frames
+let frameToken = session.videoFramePublisher.listen { frame in
+    guard let image = frame.makeUIImage() else { return }
+    Task { @MainActor in
+        self.currentFrame = image
+    }
+}
+
+// Start
+Task { await session.start() }
+```
+
+## Next steps
+
+- [Camera Streaming](camera-streaming.md) — Resolution, frame rate, photo capture
+- [MockDevice Testing](mockdevice-testing.md) — Test without hardware
+- [Session Lifecycle](session-lifecycle.md) — Handle pause/resume/stop
+- [Permissions](permissions-registration.md) — Camera permission flows
+- [Full documentation](https://wearables.developer.meta.com/docs/develop/)
+
+## Testing instructions
+
+
+Guide for testing DAT SDK integrations without physical Meta glasses.
+
+## Overview
+
+MockDeviceKit simulates Meta glasses behavior for development and testing. It provides:
+- `MockDeviceKit` — Entry point for creating simulated devices
+- `MockRaybanMeta` — Simulated Ray-Ban Meta glasses
+- `MockCameraKit` — Simulated camera with configurable video feed and photo capture
+
+## Setup
+
+Add `MWDATMockDevice` to your target via Swift Package Manager (it's included in the `meta-wearables-dat-ios` package).
+
+```swift
+import MWDATMockDevice
+```
+
+## Creating a mock device
+
+```swift
+let mockDevice = MockDeviceKit.shared.pairRaybanMeta()
+```
+
+## Simulating device states
+
+```swift
+// Simulate glasses lifecycle
+await mockDevice.powerOn()
+await mockDevice.unfold()
+await mockDevice.don()    // Simulate wearing the glasses
+
+// Later...
+await mockDevice.doff()   // Simulate removing
+await mockDevice.fold()
+await mockDevice.powerOff()
+```
+
+## Setting up mock camera feeds
+
+### Video streaming
+
+```swift
+let camera = mockDevice.getCameraKit()
+camera.setCameraFeed(fileURL: videoURL)
+```
+
+### Photo capture
+
+```swift
+let camera = mockDevice.getCameraKit()
+camera.setCapturedImage(fileURL: imageURL)
+```
+
+## Writing tests with MockDeviceKit
+
+Create a reusable test base class:
+
+```swift
+import XCTest
+import MetaWearablesDAT
+
+@MainActor
+class MockDeviceKitTestCase: XCTestCase {
+    private var mockDevice: MockRaybanMeta?
+    private var cameraKit: MockCameraKit?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try? Wearables.configure()
+        mockDevice = MockDeviceKit.shared.pairRaybanMeta()
+        cameraKit = mockDevice?.getCameraKit()
+    }
+
+    override func tearDown() async throws {
+        MockDeviceKit.shared.pairedDevices.forEach { device in
+            MockDeviceKit.shared.unpairDevice(device)
+        }
+        mockDevice = nil
+        cameraKit = nil
+        try await super.tearDown()
+    }
+}
+```
+
+## Using MockDeviceKit in the CameraAccess sample
+
+The CameraAccess sample app includes a Debug menu for MockDeviceKit:
+
+1. Tap the **Debug icon** to open the MockDeviceKit menu
+2. Tap **Pair RayBan Meta** to create a simulated device
+3. Use **PowerOn**, **Unfold**, **Don** to simulate glasses states
+4. Select video/image files to configure mock camera feeds
+5. Start streaming to see simulated frames
+
+## Supported media formats
+
+| Type | Formats |
+|------|---------|
+| Video | h.265 (HEVC) |
+| Image | JPEG, PNG |
+
+## Links
+
+- [Mock Device Kit overview](https://wearables.developer.meta.com/docs/mock-device-kit)
+- [iOS testing guide](https://wearables.developer.meta.com/docs/testing-mdk-ios)
+
+## Building and streaming
+
+
+Guide for implementing camera streaming and photo capture with the DAT SDK.
+
+## Key concepts
+
+- **StreamSession**: Main interface for camera streaming
+- **VideoFrame**: Individual video frames — call `.makeUIImage()` to render
+- **StreamSessionConfig**: Configure resolution, frame rate, and codec
+- **PhotoData**: Still image captured from glasses
+
+## Creating a StreamSession
+
+```swift
+import MWDATCamera
+import MWDATCore
+
+let wearables = Wearables.shared
+let deviceSelector = AutoDeviceSelector(wearables: wearables)
+
+let config = StreamSessionConfig(
+    videoCodec: .raw,
+    resolution: .medium,  // 504x896
+    frameRate: 24
+)
+
+let session = StreamSession(
+    streamSessionConfig: config,
+    deviceSelector: deviceSelector
+)
+```
+
+### Resolution options
+
+| Resolution | Size |
+|-----------|------|
+| `.high` | 720 x 1280 |
+| `.medium` | 504 x 896 |
+| `.low` | 360 x 640 |
+
+### Frame rate options
+
+Valid values: `2`, `7`, `15`, `24`, `30` FPS.
+
+Lower resolution and frame rate yield higher visual quality due to less Bluetooth compression.
+
+## Observing stream state
+
+`StreamSessionState` transitions: `stopping` → `stopped` → `waitingForDevice` → `starting` → `streaming` → `paused`
+
+```swift
+let stateToken = session.statePublisher.listen { state in
+    Task { @MainActor in
+        switch state {
+        case .streaming:
+            // Stream is active, frames are flowing
+        case .waitingForDevice:
+            // Waiting for glasses to connect
+        case .stopped:
+            // Stream ended — release resources
+        case .paused:
+            // Temporarily suspended — keep connection, wait
+        default:
+            break
+        }
+    }
+}
+```
+
+## Receiving video frames
+
+```swift
+let frameToken = session.videoFramePublisher.listen { frame in
+    guard let image = frame.makeUIImage() else { return }
+    Task { @MainActor in
+        self.previewImage = image
+    }
+}
+```
+
+## Starting and stopping
+
+```swift
+// Start streaming
+Task { await session.start() }
+
+// Stop streaming
+Task { await session.stop() }
+```
+
+## Photo capture
+
+Capture a still photo while streaming:
+
+```swift
+// Listen for photo data
+let photoToken = session.photoDataPublisher.listen { photoData in
+    let imageData = photoData.data
+    // Convert to UIImage or save
+}
+
+// Trigger capture
+session.capturePhoto(format: .jpeg)
+```
+
+## Bandwidth and quality
+
+Resolution and frame rate are constrained by Bluetooth Classic bandwidth. The SDK automatically reduces quality when bandwidth is limited:
+1. First lowers resolution (e.g., High → Medium)
+2. Then reduces frame rate (e.g., 30 → 24), never below 15 FPS
+
+Request lower settings for higher visual quality per frame.
+
+## Device selection
+
+Use `AutoDeviceSelector` to let the SDK pick the best device, or `SpecificDeviceSelector` for a known device:
+
+```swift
+// Auto-select
+let auto = AutoDeviceSelector(wearables: wearables)
+
+// Specific device
+let specific = SpecificDeviceSelector(deviceIdentifier: deviceId)
+```
+
+## Links
+
+- [StreamSession API reference](https://wearables.developer.meta.com/docs/reference/ios_swift/dat/0.5/mwdatcamera_streamsession)
+- [StreamSessionConfig API reference](https://wearables.developer.meta.com/docs/reference/ios_swift/dat/0.5/mwdatcamera_streamsessionconfig)
+- [Integration guide](https://wearables.developer.meta.com/docs/build-integration-ios)
+
+## Session management
+
+
+Guide for managing device session states in DAT SDK integrations.
+
+## Overview
+
+The DAT SDK runs work inside sessions. Meta glasses expose two experience types:
+- **Device sessions** — sustained access to device sensors and outputs
+- **Transactions** — short, system-owned interactions (notifications, "Hey Meta")
+
+Your app observes session state changes — the device decides when to transition.
+
+## Session states
+
+| State | Meaning | App action |
+|-------|---------|------------|
+| `STOPPED` | Session inactive, not reconnecting | Free resources, wait for user action |
+| `RUNNING` | Session active, streaming data | Perform live work |
+| `PAUSED` | Temporarily suspended | Hold work, may resume |
+
+## Observing session state
+
+```swift
+Task {
+    for await state in Wearables.shared.deviceSessionStateStream(for: deviceId) {
+        switch state {
+        case .running:
+            // Confirm UI shows session is live
+        case .paused:
+            // Keep connection, wait for running or stopped
+        case .stopped:
+            // Release resources, allow user to restart
+        }
+    }
+}
+```
+
+## StreamSession state transitions
+
+StreamSession has its own state flow:
+
+```text
+stopped → waitingForDevice → starting → streaming → paused → stopped
+```
+
+```swift
+let token = session.statePublisher.listen { state in
+    Task { @MainActor in
+        // React to state changes
+    }
+}
+```
+
+## Common transitions
+
+The device changes session state when:
+- User performs a system gesture that opens another experience
+- Another app starts a device session
+- User removes or folds the glasses (Bluetooth disconnects)
+- User removes the app from Meta AI companion app
+- Connectivity between companion app and glasses drops
+
+## Pause and resume
+
+When a session is paused:
+- The device keeps the connection alive
+- Streams stop delivering data
+- The device may resume by returning to `RUNNING`
+
+Your app should **not** attempt to restart while paused — wait for `RUNNING` or `STOPPED`.
+
+## Device availability
+
+Monitor device availability to know when sessions can start:
+
+```swift
+Task {
+    for await devices in Wearables.shared.devicesStream() {
+        // Update list of available glasses
+    }
+}
+```
+
+Key behaviors:
+- Closing hinges disconnects Bluetooth → forces `STOPPED`
+- Opening hinges restores Bluetooth but does **not** restart sessions
+- Start a new session after the device becomes available again
+
+## Implementation checklist
+
+- [ ] Handle all session states (`RUNNING`, `PAUSED`, `STOPPED`)
+- [ ] Monitor device availability before starting work
+- [ ] Release resources only after `STOPPED`
+- [ ] Don't infer transition causes — rely only on observable state
+- [ ] Don't restart during `PAUSED` — wait for system to resume or stop
+
+## Links
+
+- [Session lifecycle documentation](https://wearables.developer.meta.com/docs/lifecycle-events)
+
+## Permissions
+
+
+Guide for app registration and camera permission flows in the DAT SDK.
+
+## Overview
+
+The DAT SDK separates two concepts:
+1. **Registration** — Your app registers with Meta AI to become a permitted integration
+2. **Device permissions** — After registration, request specific device permissions (e.g., camera)
+
+All permission grants occur through the Meta AI companion app.
+
+## Registration flow
+
+### Start registration
+
+```swift
+func startRegistration() throws {
+    try Wearables.shared.startRegistration()
+}
+```
+
+This opens the Meta AI app where the user approves your app. Meta AI then calls back via your URL scheme.
+
+### Handle the callback
+
+```swift
+.onOpenURL { url in
+    Task {
+        _ = try? await Wearables.shared.handleUrl(url)
+    }
+}
+```
+
+### Observe registration state
+
+```swift
+Task {
+    for await state in Wearables.shared.registrationStateStream() {
+        switch state {
+        case .registered:
+            // App is registered, can request permissions
+        case .unregistered:
+            // App is not registered
+        case .registering:
+            // Registration in progress
+        }
+    }
+}
+```
+
+### Unregister
+
+```swift
+func startUnregistration() throws {
+    try Wearables.shared.startUnregistration()
+}
+```
+
+## Camera permissions
+
+### Check permission status
+
+```swift
+let status = try await Wearables.shared.checkPermissionStatus(.camera)
+```
+
+### Request permission
+
+```swift
+let status = try await Wearables.shared.requestPermission(.camera)
+```
+
+The SDK opens Meta AI for the user to grant access. Users can choose:
+- **Allow once** — temporary, single-session grant
+- **Allow always** — persistent grant
+
+## Multi-device behavior
+
+Users can link multiple glasses to Meta AI. The SDK handles this transparently:
+- Permission granted on **any** linked device means your app has access
+- You don't need to track which device has permissions
+- If all devices disconnect, permissions become unavailable
+
+## Developer Mode vs Production
+
+| Mode | Registration behavior |
+|------|----------------------|
+| Developer Mode | Registration always allowed (use `MetaAppID` = `0`) |
+| Production | Users must be in proper release channel |
+
+For production, get your `APPLICATION_ID` from the [Wearables Developer Center](https://wearables.developer.meta.com/).
+
+## Prerequisites
+
+- Registration requires an internet connection
+- Meta AI companion app must be installed
+- For Developer Mode: enable in Meta AI > Settings > Your glasses > Developer Mode
+
+## Links
+
+- [Permissions documentation](https://wearables.developer.meta.com/docs/permissions-requests)
+- [Getting started guide](https://wearables.developer.meta.com/docs/getting-started-toolkit)
+- [Manage projects](https://wearables.developer.meta.com/docs/manage-projects)
+
+## Debugging
+
+
+Guide for diagnosing common issues with DAT SDK integrations.
+
+## Quick diagnosis
+
+```text
+Device not connecting?
+│
+├── Is Developer Mode enabled? → Enable in Meta AI app settings
+│
+├── Is device registered? → Check registration state
+│
+├── Is device in range? → Bluetooth on, glasses powered on
+│
+├── Is the app registered? → Check registrationStateStream()
+│
+└── Stream stuck in waitingForDevice? → Check device availability
+```
+
+## Developer Mode
+
+Developer Mode must be enabled for 3P apps to access device features.
+
+### Enabling Developer Mode
+
+1. Open Meta AI app on phone
+2. Go to Settings → (Your connected glasses)
+3. Find "Developer Mode" toggle
+4. Toggle ON
+5. Device may restart
+
+### Symptoms of Developer Mode disabled
+
+- Registration completes but device never connects
+- StreamSession stuck in `waitingForDevice`
+- Permission requests fail or never appear
+
+### Common gotchas
+
+- Developer Mode toggles **off** after firmware updates — re-enable it
+- Developer Mode is per-device — enable for each glasses pair
+- Some features need additional permissions beyond Developer Mode
+
+## StreamSession state issues
+
+### Expected flow
+
+```text
+stopped → waitingForDevice → starting → streaming → stopped
+```
+
+### Stuck in waitingForDevice
+
+- Device not in range or not connected
+- Device not reporting availability
+- DeviceSelector not matching any device
+
+### Unexpected stop
+
+- Device disconnected (out of range, battery died)
+- Channel closed by device
+- Error in frame processing
+
+## Version compatibility
+
+Ensure compatible versions of SDK, Meta AI app, and glasses firmware:
+
+| SDK | Meta AI App | Ray-Ban Meta | Meta Ray-Ban Display |
+|-----|-------------|--------------|----------------------|
+| 0.5.0 | Check [version dependencies](https://wearables.developer.meta.com/docs/version-dependencies) | Check docs | Check docs |
+| 0.4.0 | V254 | V20 | V21 |
+| 0.3.0 | V249 | V20 | — |
+
+## Known issues
+
+| Issue | Workaround |
+|-------|-----------|
+| No internet → registration fails | Internet required for registration |
+| Streams started with glasses doffed pause when donned | Unpause by tapping side of glasses |
+| `DeviceStateSession` unreliable with camera stream | Avoid using `DeviceStateSession` |
+| [iOS] Meta Ray-Ban Display: no audio feedback on pause/resume | Will be fixed in future release |
+
+## Adding debug logging
+
+```swift
+import os
+
+private let logger = Logger(subsystem: "com.yourapp", category: "Wearables")
+
+// In your streaming code:
+logger.debug("Stream state changed to: \(state)")
+logger.error("Stream error: \(error)")
+```
+
+## Checklist
+
+- [ ] Developer Mode enabled in Meta AI app
+- [ ] Meta AI app updated to compatible version
+- [ ] Glasses firmware updated to compatible version
+- [ ] Internet connection available for registration
+- [ ] Bluetooth enabled on phone
+- [ ] Correct URL scheme configured in Info.plist
+- [ ] Background modes enabled (bluetooth-peripheral, external-accessory)
+
+## Links
+
+- [Known issues](https://wearables.developer.meta.com/docs/knownissues)
+- [Version dependencies](https://wearables.developer.meta.com/docs/version-dependencies)
+- [Troubleshooting discussions](https://github.com/facebook/meta-wearables-dat-ios/discussions)
+
+## Sample app
+
+
+Guide for building a complete DAT SDK app with camera streaming and photo capture.
+
+## Overview
+
+This guide walks through building an iOS app that connects to Meta glasses, streams video, and captures photos. Use it as a reference alongside the [CameraAccess sample](https://github.com/facebook/meta-wearables-dat-ios/tree/main/samples).
+
+## Project setup
+
+1. Create a new Xcode project (SwiftUI App)
+2. Add the SDK via SPM: `https://github.com/facebook/meta-wearables-dat-ios`
+3. Add `MWDATCore`, `MWDATCamera`, and `MWDATMockDevice` to your target
+4. Configure `Info.plist` (see [Getting Started](getting-started.md))
+
+## App architecture
+
+A typical DAT app has these components:
+
+```text
+MyDATApp/
+├── MyDATApp.swift              # App entry point, SDK init
+├── ViewModels/
+│   ├── WearablesViewModel.swift    # Registration, device management
+│   └── StreamSessionViewModel.swift # Streaming, photo capture
+└── Views/
+    ├── MainAppView.swift           # Navigation
+    ├── RegistrationView.swift      # Registration UI
+    └── StreamView.swift            # Video preview, capture button
+```
+
+## SDK initialization
+
+```swift
+import MWDATCore
+
+@main
+struct MyDATApp: App {
+    init() {
+        do {
+            try Wearables.configure()
+        } catch {
+            assertionFailure("Wearables SDK configuration failed: \(error)")
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            MainAppView()
+                .onOpenURL { url in
+                    Task {
+                        _ = try? await Wearables.shared.handleUrl(url)
+                    }
+                }
+        }
+    }
+}
+```
+
+## Wearables ViewModel
+
+```swift
+import MWDATCore
+
+@MainActor
+class WearablesViewModel: ObservableObject {
+    @Published var registrationState: String = "Unknown"
+    @Published var devices: [DeviceIdentifier] = []
+
+    private let wearables = Wearables.shared
+
+    func observeState() {
+        Task {
+            for await state in wearables.registrationStateStream() {
+                self.registrationState = "\(state)"
+            }
+        }
+        Task {
+            for await devices in wearables.devicesStream() {
+                self.devices = devices.map { $0.identifier }
+            }
+        }
+    }
+
+    func register() {
+        try? wearables.startRegistration()
+    }
+
+    func unregister() {
+        try? wearables.startUnregistration()
+    }
+}
+```
+
+## Stream ViewModel
+
+```swift
+import MWDATCamera
+import MWDATCore
+
+@MainActor
+class StreamSessionViewModel: ObservableObject {
+    @Published var currentFrame: UIImage?
+    @Published var streamState: String = "Stopped"
+    @Published var capturedPhoto: Data?
+
+    private var session: StreamSession?
+
+    func startStream() {
+        let wearables = Wearables.shared
+        let config = StreamSessionConfig(
+            videoCodec: .raw,
+            resolution: .medium,
+            frameRate: 24
+        )
+        let selector = AutoDeviceSelector(wearables: wearables)
+        let session = StreamSession(streamSessionConfig: config, deviceSelector: selector)
+        self.session = session
+
+        _ = session.statePublisher.listen { [weak self] state in
+            Task { @MainActor in
+                self?.streamState = "\(state)"
+            }
+        }
+
+        _ = session.videoFramePublisher.listen { [weak self] frame in
+            guard let image = frame.makeUIImage() else { return }
+            Task { @MainActor in
+                self?.currentFrame = image
+            }
+        }
+
+        _ = session.photoDataPublisher.listen { [weak self] photoData in
+            Task { @MainActor in
+                self?.capturedPhoto = photoData.data
+            }
+        }
+
+        Task { await session.start() }
+    }
+
+    func stopStream() {
+        Task { await session?.stop() }
+        session = nil
+    }
+
+    func capturePhoto() {
+        session?.capturePhoto(format: .jpeg)
+    }
+}
+```
+
+## Testing with MockDeviceKit
+
+Add mock device support to develop without glasses:
+
+```swift
+import MWDATMockDevice
+
+func setupMockDevice() async {
+    let device = MockDeviceKit.shared.pairRaybanMeta()
+    await device?.powerOn()
+    await device?.unfold()
+    await device?.don()
+
+    // Set up mock camera feed
+    if let videoURL = Bundle.main.url(forResource: "test_video", withExtension: "mov") {
+        let camera = device?.getCameraKit()
+        await camera?.setCameraFeed(fileURL: videoURL)
+    }
+}
+```
+
+## Allowed dependencies
+
+Your DAT app should only depend on:
+- `MWDATCore` — always required
+- `MWDATCamera` — for camera streaming
+- `MWDATMockDevice` — for testing (can be test-only dependency)
+
+## Links
+
+- [CameraAccess sample](https://github.com/facebook/meta-wearables-dat-ios/tree/main/samples)
+- [Full integration guide](https://wearables.developer.meta.com/docs/build-integration-ios)
+- [Developer documentation](https://wearables.developer.meta.com/docs/develop/)

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/meta-wearables-dat-ios",
       "state" : {
-        "revision" : "b67454b6f081373f757476ecb3b4973bf33bc326",
-        "version" : "0.4.0"
+        "revision" : "2ea30fa228359315baf71c404aec821472e994c1",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/facebook/meta-wearables-dat-ios", from: "0.4.0")
+    .package(url: "https://github.com/facebook/meta-wearables-dat-ios", from: "0.5.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/thing-finder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/thing-finder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/meta-wearables-dat-ios",
       "state" : {
-        "revision" : "b67454b6f081373f757476ecb3b4973bf33bc326",
-        "version" : "0.4.0"
+        "revision" : "2ea30fa228359315baf71c404aec821472e994c1",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -62,8 +62,10 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   }
 
   deinit {
-    // Note: Cannot call MainActor-isolated stop() from deinit
-    // The streamSession will be cleaned up automatically
+    // Clean up stream session
+    Task { @MainActor [streamSession] in
+      await streamSession?.stop()
+    }
   }
 
   // MARK: - FrameProvider Methods
@@ -71,27 +73,15 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   func setupSession() {
     guard streamSession == nil else { return }
 
-    // SDK requires MainActor - dispatch synchronously since we're likely already on main
-    if Thread.isMainThread {
-      MainActor.assumeIsolated {
-        setupSessionOnMain()
-      }
-    } else {
-      DispatchQueue.main.sync {
-        MainActor.assumeIsolated { [self] in
-          setupSessionOnMain()
-        }
-      }
+    // Must be called on MainActor for MWDATCamera
+    Task { @MainActor in
+      self.setupSessionOnMain()
     }
   }
 
   @MainActor
   private func setupSessionOnMain() {
     guard streamSession == nil else { return }
-
-    print("[MetaGlassesFrameProvider] Setting up session...")
-    print("[MetaGlassesFrameProvider] Registration state: \(Wearables.shared.registrationState)")
-    print("[MetaGlassesFrameProvider] Current devices: \(Wearables.shared.devices)")
 
     let wearables = Wearables.shared
     deviceSelector = AutoDeviceSelector(wearables: wearables)
@@ -107,7 +97,6 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
       return
     }
     streamSession = StreamSession(streamSessionConfig: config, deviceSelector: selector)
-    print("[MetaGlassesFrameProvider] StreamSession created")
 
     // Subscribe to video frames
     videoFrameListenerToken = streamSession?.videoFramePublisher.listen { [weak self] videoFrame in
@@ -121,7 +110,6 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     stateListenerToken = streamSession?.statePublisher.listen { [weak self] state in
       Task { @MainActor [weak self] in
         guard let self else { return }
-        print("[MetaGlassesFrameProvider] State changed: \(state)")
         switch state {
         case .streaming:
           self.isRunning = true
@@ -131,7 +119,6 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
           self.isRunning = false
           MetaGlassesManager.shared.isStreamActive = false
         case .waitingForDevice:
-          // Glasses not available - signal fallback needed
           MetaGlassesManager.shared.isStreamActive = false
         default:
           break
@@ -140,11 +127,7 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     }
 
     // Subscribe to errors
-    errorListenerToken = streamSession?.errorPublisher.listen { error in
-      Task { @MainActor in
-        print("[MetaGlassesFrameProvider] Stream error: \(error)")
-      }
-    }
+    errorListenerToken = streamSession?.errorPublisher.listen { _ in }
   }
 
   func start() {
@@ -154,45 +137,62 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     Task { @MainActor [weak self] in
       guard let self else { return }
       defer { self.isStarting = false }
-      // Check if we have any devices available
-      let devices = Wearables.shared.devices
-      print("[MetaGlassesFrameProvider] Available devices: \(devices)")
+
+      // Reset failure flag for fresh attempt
+      MetaGlassesManager.shared.streamStartFailed = false
+
+      // Ensure session is set up before starting
+      if self.streamSession == nil {
+        self.setupSessionOnMain()
+      }
+
+      // Wait briefly for devices to become available if needed
+      var devices = Wearables.shared.devices
+      if devices.isEmpty {
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        devices = Wearables.shared.devices
+      }
 
       if !devices.isEmpty {
-        // Only check permissions if we have a real device
+        // Check and request permissions
         do {
           let permission = Permission.camera
-          let status = try await Wearables.shared.checkPermissionStatus(permission)
-          print("[MetaGlassesFrameProvider] Permission status: \(status)")
 
-          if status != .granted {
-            print("[MetaGlassesFrameProvider] Permission not granted, requesting...")
+          var needsRequest = false
+          do {
+            let status = try await Wearables.shared.checkPermissionStatus(permission)
+            needsRequest = (status != .granted)
+          } catch {
+            needsRequest = true
+          }
+
+          if needsRequest {
+            MetaGlassesManager.shared.isPermissionRequestInProgress = true
             let requestStatus = try await Wearables.shared.requestPermission(permission)
-            guard requestStatus == .granted else {
-              print("[MetaGlassesFrameProvider] Camera permission denied after request")
+            MetaGlassesManager.shared.isPermissionRequestInProgress = false
+            if requestStatus != .granted {
               MetaGlassesManager.shared.isStreamActive = false
+              MetaGlassesManager.shared.errorMessage =
+                "Camera permission required. Please grant access in Meta AI app."
               return
             }
           }
         } catch {
-          print("[MetaGlassesFrameProvider] Permission check/request failed: \(error)")
-          // Permission failed - glasses can't stream, signal fallback
+          MetaGlassesManager.shared.isPermissionRequestInProgress = false
           MetaGlassesManager.shared.isStreamActive = false
-          MetaGlassesManager.shared.streamStartFailed = true
           MetaGlassesManager.shared.errorMessage =
-            "Camera permission required. Open Meta AI app to grant access."
+            "Camera permission required. Please grant access in Meta AI app."
           return
         }
       } else {
-        print("[MetaGlassesFrameProvider] No devices available")
         MetaGlassesManager.shared.isStreamActive = false
         MetaGlassesManager.shared.streamStartFailed = true
         return
       }
 
-      // Start the session - we have devices and permission
-      await streamSession?.start()
-      print("[MetaGlassesFrameProvider] Session started")
+      // Start the session
+      guard self.streamSession != nil else { return }
+      await self.streamSession?.start()
     }
   }
 
@@ -200,10 +200,25 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     guard isRunning || isStarting || streamSession != nil else { return }
 
     Task { @MainActor in
-      await streamSession?.stop()
-      isRunning = false
-      MetaGlassesManager.shared.isStreamActive = false
+      await self.teardownSession()
     }
+  }
+
+  @MainActor
+  private func teardownSession() async {
+    await streamSession?.stop()
+
+    // Clear listener tokens
+    stateListenerToken = nil
+    videoFrameListenerToken = nil
+    errorListenerToken = nil
+
+    // Clear session so a fresh one is created on next start
+    streamSession = nil
+    deviceSelector = nil
+
+    isRunning = false
+    MetaGlassesManager.shared.isStreamActive = false
   }
 
   // MARK: - Video Frame Handling
@@ -213,9 +228,6 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   @MainActor
   private func handleVideoFrame(_ videoFrame: VideoFrame) {
     frameCount += 1
-    if frameCount % 30 == 1 {
-      print("[MetaGlassesFrameProvider] Received frame #\(frameCount)")
-    }
 
     // Update preview
     if let uiImage = videoFrame.makeUIImage() {

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -172,6 +172,7 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
             MetaGlassesManager.shared.isPermissionRequestInProgress = false
             if requestStatus != .granted {
               MetaGlassesManager.shared.isStreamActive = false
+              MetaGlassesManager.shared.streamStartFailed = true
               MetaGlassesManager.shared.errorMessage =
                 "Camera permission required. Please grant access in Meta AI app."
               return
@@ -180,6 +181,7 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
         } catch {
           MetaGlassesManager.shared.isPermissionRequestInProgress = false
           MetaGlassesManager.shared.isStreamActive = false
+          MetaGlassesManager.shared.streamStartFailed = true
           MetaGlassesManager.shared.errorMessage =
             "Camera permission required. Please grant access in Meta AI app."
           return

--- a/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
+++ b/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
@@ -37,6 +37,9 @@ public final class MetaGlassesManager: ObservableObject {
   /// Tracks if the stream failed to start (e.g., permission denied) - triggers fallback
   @Published public var streamStartFailed: Bool = false
 
+  /// Tracks if permission request is in progress (app may go to background for Meta AI)
+  @Published public var isPermissionRequestInProgress: Bool = false
+
   private var registrationTask: Task<Void, Never>?
   private var deviceStreamTask: Task<Void, Never>?
 
@@ -49,49 +52,63 @@ public final class MetaGlassesManager: ObservableObject {
       try Wearables.configure()
       isConfigured = true
 
-      // Listen for registration state changes
+      // Check current registration state synchronously on launch
+      // This handles the case where the app relaunches with persisted registration
+      let currentState = Wearables.shared.registrationState
+      // print("[MetaGlassesManager] Initial registration state: \(currentState)")
+      handleRegistrationState(currentState, isInitial: true)
+
+      // Listen for future registration state changes
       registrationTask = Task {
         for await state in Wearables.shared.registrationStateStream() {
-          print("[MetaGlassesManager] Registration state: \(state)")
-          self.isRegistered = (state == .registered)
-
-          switch state {
-          case .registered:
-            // If we were in registration flow, show success modal
-            if self.isRegistrationInProgress {
-              self.shouldShowRegistrationSuccess = true
-            }
-            self.hasEverRegistered = true
-            self.isRegistrationInProgress = false
-            await self.setupDeviceStream()
-            print("[MetaGlassesManager] isReadyForUse: \(self.isReadyForUse)")
-
-          case .registering:
-            self.isRegistrationInProgress = true
-
-          default:
-            // Any state other than registered/registering means unregistered
-            self.hasEverRegistered = false
-            self.isRegistrationInProgress = false
-            self.isStreamActive = false
-            self.streamStartFailed = false
-            self.availableDevices = []
-            self.deviceStreamTask?.cancel()
-            self.deviceStreamTask = nil
-            print("[MetaGlassesManager] State \(state) - state reset")
-          }
+          // print("[MetaGlassesManager] Registration state changed: \(state)")
+          self.handleRegistrationState(state, isInitial: false)
         }
       }
     } catch {
       errorMessage = "Failed to configure Wearables SDK: \(error)"
-      print("[MetaGlassesManager] \(errorMessage!)")
+      // print("[MetaGlassesManager] \(errorMessage!)")
+    }
+  }
+
+  private func handleRegistrationState(_ state: RegistrationState, isInitial: Bool) {
+    self.isRegistered = (state == .registered)
+
+    switch state {
+    case .registered:
+      // If we were in registration flow (not initial), show success modal
+      if self.isRegistrationInProgress && !isInitial {
+        self.shouldShowRegistrationSuccess = true
+      }
+      self.hasEverRegistered = true
+      self.isRegistrationInProgress = false
+      // Immediately fetch current devices synchronously to avoid race condition
+      self.availableDevices = Wearables.shared.devices
+      Task {
+        await self.setupDeviceStream()
+      }
+    // print("[MetaGlassesManager] isReadyForUse: \(self.isReadyForUse)")
+
+    case .registering:
+      self.isRegistrationInProgress = true
+
+    default:
+      // Any state other than registered/registering means unregistered
+      self.hasEverRegistered = false
+      self.isRegistrationInProgress = false
+      self.isStreamActive = false
+      self.streamStartFailed = false
+      self.availableDevices = []
+      self.deviceStreamTask?.cancel()
+      self.deviceStreamTask = nil
+    // print("[MetaGlassesManager] State \(state) - state reset")
     }
   }
 
   private func setupDeviceStream() async {
     // Immediately check current devices
     self.availableDevices = Wearables.shared.devices
-    print("[MetaGlassesManager] Initial devices: \(self.availableDevices)")
+    // print("[MetaGlassesManager] Initial devices: \(self.availableDevices)")
 
     deviceStreamTask?.cancel()
     deviceStreamTask = Task {

--- a/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
+++ b/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
@@ -96,6 +96,7 @@ public final class MetaGlassesManager: ObservableObject {
       // Any state other than registered/registering means unregistered
       self.hasEverRegistered = false
       self.isRegistrationInProgress = false
+      self.isPermissionRequestInProgress = false
       self.isStreamActive = false
       self.streamStartFailed = false
       self.availableDevices = []

--- a/thing-finder/Views/CameraPreviewView.swift
+++ b/thing-finder/Views/CameraPreviewView.swift
@@ -94,8 +94,8 @@ struct CameraPreviewView: UIViewControllerRepresentable {
         }
       }
     } else {
-      // Don't stop if Meta glasses permission request is in progress
-      if MetaGlassesManager.shared.isPermissionRequestInProgress {
+      // Don't stop Meta glasses capture while permission request is in progress
+      if source == .metaGlasses && MetaGlassesManager.shared.isPermissionRequestInProgress {
         return
       }
       capture.stop()

--- a/thing-finder/Views/CameraPreviewView.swift
+++ b/thing-finder/Views/CameraPreviewView.swift
@@ -41,7 +41,6 @@ struct CameraPreviewView: UIViewControllerRepresentable {
   }
 
   func makeUIViewController(context: Context) -> UIViewController {
-    print("Creating camera preview view controller...")
     let vc = UIViewController()
     vc.view.backgroundColor = .black
 
@@ -70,28 +69,24 @@ struct CameraPreviewView: UIViewControllerRepresentable {
       }
     }
 
-    print("Preview view controller created with frame: \(preview.frame)")
     return vc
   }
 
   func updateUIViewController(_ uiVC: UIViewController, context: Context) {
-    print("Updating camera preview view controller (isRunning: \(isRunning))")
-
     // Check if source changed and swap provider if needed
-    context.coordinator.updateSource(source, delegate: delegate)
+    let sourceChanged = context.coordinator.updateSource(
+      source, delegate: delegate, parentView: uiVC.view)
 
     let capture = context.coordinator.videoCapture
 
     // Update delegate if needed
     if capture.delegate !== delegate {
-      print("Updating capture delegate")
       capture.delegate = delegate
     }
 
     // Start/stop capture as needed
     if isRunning {
       DispatchQueue.main.async {
-        print("Starting capture from update")
         context.coordinator.setupIfNeeded()
         // Only start if not already running to avoid duplicate starts
         if !capture.isRunning {
@@ -99,7 +94,10 @@ struct CameraPreviewView: UIViewControllerRepresentable {
         }
       }
     } else {
-      print("Stopping capture from update")
+      // Don't stop if Meta glasses permission request is in progress
+      if MetaGlassesManager.shared.isPermissionRequestInProgress {
+        return
+      }
       capture.stop()
     }
   }
@@ -134,8 +132,15 @@ struct CameraPreviewView: UIViewControllerRepresentable {
       }
     }
 
-    func updateSource(_ newSource: CaptureSourceType, delegate: FrameProviderDelegate?) {
-      guard newSource != currentSource else { return }
+    @discardableResult
+    func updateSource(
+      _ newSource: CaptureSourceType, delegate: FrameProviderDelegate?, parentView: UIView
+    ) -> Bool {
+      guard newSource != currentSource else { return false }
+
+      // Remove old preview view
+      let oldPreview = videoCapture.previewView
+      oldPreview.removeFromSuperview()
 
       // Stop old provider
       if videoCapture.isRunning {
@@ -147,6 +152,17 @@ struct CameraPreviewView: UIViewControllerRepresentable {
       videoCapture = Self.createProvider(for: newSource)
       videoCapture.delegate = delegate
       hasSetUpSession = false
+
+      // Add new preview view
+      let newPreview = videoCapture.previewView
+      newPreview.frame = parentView.bounds
+      newPreview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      newPreview.contentMode = .scaleAspectFill
+      newPreview.clipsToBounds = true
+      parentView.addSubview(newPreview)
+      parentView.sendSubviewToBack(newPreview)
+
+      return true
     }
 
     func setupIfNeeded() {

--- a/thing-finder/Views/DetectorContainer.swift
+++ b/thing-finder/Views/DetectorContainer.swift
@@ -51,7 +51,9 @@ struct DetectorContainer: View {
   private var captureSource: CaptureSourceType {
     if settings.useMetaGlasses
       && !metaGlassesManager.streamStartFailed
-      && (metaGlassesManager.isStreamActive || metaGlassesManager.isReadyForUse)
+      && (metaGlassesManager.isStreamActive
+        || metaGlassesManager.isReadyForUse
+        || metaGlassesManager.isPermissionRequestInProgress)
     {
       return .metaGlasses
     }


### PR DESCRIPTION
SDK 0.5 compatibility - Updated code to work with Meta DAT SDK patterns
Reconnection on app relaunch - Added synchronous check of Wearables.shared.registrationState and devices on init in MetaGlassesManager
Permission flow - Added isPermissionRequestInProgress flag to prevent stream teardown when app goes to background for Meta AI permission grant
Preview layer switching - Fixed CameraPreviewView.Coordinator.updateSource() to properly swap preview views when source changes
Capture source selection - Updated DetectorContainer.captureSource to include isPermissionRequestInProgress in the condition
