### PR TITLE
Fix Meta Glasses streaming reliability

### DIFF
--- a/KNOWN_BUGS.md
+++ b/KNOWN_BUGS.md
@@ -1,0 +1,23 @@
+# Known Bugs
+
+## Meta Glasses: Phone camera fallback after unpair/repair in same session
+
+**Status:** Open
+
+**Description:**
+When unpairing and repairing Meta glasses within the same app session, the camera falls back to the phone camera instead of using the glasses stream.
+
+**Root Cause:**
+`DetectorContainer.captureSource` requires `streamSessionVM.isStreaming || streamSessionVM.hasActiveDevice` to be true before returning `.metaGlasses`. However, when registration completes, these values are not yet populated because:
+1. `hasActiveDevice` depends on `AutoDeviceSelector.activeDeviceStream()`, an async stream that doesn't emit immediately
+2. `isStreaming` is only true after the stream has started
+
+By the time `captureSource` is evaluated, both values are still `false`, so it returns `.avFoundation` (phone camera).
+
+**Workaround:**
+Close and reopen the app after repairing glasses.
+
+**Potential Fixes (not yet implemented):**
+1. Proactively start streaming when registration completes (in `MetaGlassesEnvironment`)
+2. Use `wearablesVM.devices.isEmpty` as the guard instead of `hasActiveDevice`
+3. Add a delay/retry mechanism when registration completes to wait for device availability

--- a/thing-finder.code-workspace
+++ b/thing-finder.code-workspace
@@ -1,8 +1,11 @@
 {
 	"folders": [
-		{
-			"path": "."
-		}
-	],
+    {
+      "path": "."
+    },
+    {
+      "path": "../../../../Downloads/meta-wearables-dat-ios-main 3"
+    }
+  ],
   "settings": {}
 }

--- a/thing-finder.code-workspace
+++ b/thing-finder.code-workspace
@@ -2,9 +2,6 @@
 	"folders": [
     {
       "path": "."
-    },
-    {
-      "path": "../../../../Downloads/meta-wearables-dat-ios-main 3"
     }
   ],
   "settings": {}

--- a/thing-finder.xcodeproj/xcuserdata/smehta.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/thing-finder.xcodeproj/xcuserdata/smehta.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -324,5 +324,117 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "761AF99F-4039-4B1F-8A6C-285D10A4C15C"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/MetaGlassesManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "236"
+            endingLineNumber = "236"
+            landmarkName = "MetaGlassesManager"
+            landmarkType = "3">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "8A184CEC-41FE-42E3-B302-2D21E0AC9E03"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/MetaGlassesManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "261"
+            endingLineNumber = "261"
+            landmarkName = "ensureCameraPermission()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "13F32D7D-7CC1-4285-A5CD-E64AD90A6D4A"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/MetaGlassesManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "257"
+            endingLineNumber = "257"
+            landmarkName = "ensureCameraPermission()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "507B07BC-5F26-4DA4-8612-16F922ECB047"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/MetaGlassesManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "237"
+            endingLineNumber = "237"
+            landmarkName = "MetaGlassesManager"
+            landmarkType = "3">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "92D23ED4-3BC1-45A4-9EE0-04C376D07506"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/MetaGlassesManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "252"
+            endingLineNumber = "252"
+            landmarkName = "ensureCameraPermission()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "4F9091B4-3242-4CC9-8B32-10D487508886"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Views/DetectorContainer.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "54"
+            endingLineNumber = "54"
+            landmarkName = "DetectorContainer"
+            landmarkType = "14">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "9F67A586-2EF3-4130-A174-0D21B096D12E"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "thing-finder/Services/MetaGlasses/WearablesViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "45"
+            endingLineNumber = "45"
+            landmarkName = "init(wearables:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/thing-finder/App/App.swift
+++ b/thing-finder/App/App.swift
@@ -4,16 +4,34 @@ import SwiftUI
 
 @main
 struct ThingFinderApp: App {
+  @StateObject private var glassesEnvironment = MetaGlassesEnvironment.shared
+
+  init() {
+    // Configure Wearables SDK on launch (matches Meta sample pattern)
+    do {
+      try Wearables.configure()
+    } catch {
+      print("[ThingFinderApp] Failed to configure Wearables SDK: \(error)")
+    }
+  }
+
   var body: some Scene {
     WindowGroup {
       MainTabView()
+        .environmentObject(glassesEnvironment.wearablesViewModel)
+        .environmentObject(glassesEnvironment.streamSessionViewModel)
         .onOpenURL { url in
           // Handle callback from Meta AI app after registration/permission flows
-          guard url.scheme == "thingfinder" else { return }
+          // Filter for DAT SDK URLs using metaWearablesAction param (matches Meta sample)
+          guard
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            components.queryItems?.contains(where: { $0.name == "metaWearablesAction" }) == true
+          else { return }
           Task {
             do {
               _ = try await Wearables.shared.handleUrl(url)
-              print("[ThingFinderApp] Handled Meta AI callback URL: \(url)")
+            } catch let error as RegistrationError {
+              print("[ThingFinderApp] Registration error: \(error.description)")
             } catch {
               print("[ThingFinderApp] Failed to handle URL: \(error)")
             }

--- a/thing-finder/App/AppShortcuts.swift
+++ b/thing-finder/App/AppShortcuts.swift
@@ -22,6 +22,27 @@ struct FindCarIntent: AppIntent {
   }
 }
 
+// MARK: - Find Paratransit Intent (with spoken description)
+
+struct FindParatransitIntent: AppIntent {
+  static var title: LocalizedStringResource = "Find My Paratransit"
+  static var description = IntentDescription("Start searching for your paratransit vehicle with a description")
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(
+    title: "Paratransit Description",
+    description: "Describe your paratransit vehicle (e.g., blue bus with wheelchair ramp)",
+    requestValueDialog: "What does your paratransit vehicle look like?"
+  )
+  var paratransitDescription: String
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    ShortcutNavigationState.shared.pendingParatransitDescription = paratransitDescription
+    return .result()
+  }
+}
+
 // MARK: - App Shortcuts Provider
 
 struct ThingFinderShortcuts: AppShortcutsProvider {
@@ -35,6 +56,16 @@ struct ThingFinderShortcuts: AppShortcutsProvider {
       ],
       shortTitle: "Find My Car",
       systemImageName: "car.fill"
+    );
+    AppShortcut(
+      intent: FindParatransitIntent(),
+      phrases: [
+        "Find my paratransit vehicle with \(.applicationName)",
+        "Find my bus with \(.applicationName)",
+        "\(.applicationName) Paratransit",
+      ],
+      shortTitle: "Find My Paratransit",
+      systemImageName: "bus.fill"
     )
   }
 }
@@ -47,12 +78,17 @@ final class ShortcutNavigationState {
   static let shared = ShortcutNavigationState()
 
   var pendingCarDescription: String? = nil
-
+  var pendingParatransitDescription: String? = nil
   private init() {}
 
   func consumePendingDescription() -> String? {
     let description = pendingCarDescription
     pendingCarDescription = nil
+    return description
+  }
+  func consumePendingParatransitDescription() -> String? {
+    let description = pendingParatransitDescription
+    pendingParatransitDescription = nil
     return description
   }
 }

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -99,7 +99,7 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     }
   }
 
-  func stop() {
+  @MainActor func stop() {
     guard isRunning else { return }
     // Set synchronously so a concurrent start() Task sees the updated flag after its await
     isRunning = false

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -25,6 +25,8 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
 
   private let streamSessionVM: StreamSessionViewModel
   private var frameObservationTask: Task<Void, Never>?
+  /// Tracks the last frame sent to the delegate to avoid reprocessing the same UIImage.
+  private weak var lastFrameRef: UIImage?
 
   private let previewImageView: UIImageView = {
     let iv = UIImageView()
@@ -60,13 +62,15 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   func setupSession() {
     // Start observing frames from the view model
     frameObservationTask?.cancel()
+    lastFrameRef = nil
     frameObservationTask = Task { @MainActor [weak self] in
       guard let self else { return }
       while !Task.isCancelled {
-        if let frame = self.streamSessionVM.currentVideoFrame {
+        if let frame = self.streamSessionVM.currentVideoFrame, frame !== self.lastFrameRef {
+          self.lastFrameRef = frame
           self.previewImageView.image = frame
-          // Convert UIImage back to CVPixelBuffer for the delegate
-          if let pixelBuffer = frame.pixelBuffer() {
+          // Use zero-copy pixel buffer extracted directly from the SDK's CMSampleBuffer
+          if let pixelBuffer = self.streamSessionVM.currentPixelBuffer {
             self.delegate?.processFrame(self, buffer: pixelBuffer, depthAt: { _ in nil })
           }
         }
@@ -77,69 +81,33 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
 
   func start() {
     guard !isRunning else { return }
+    // Set synchronously so a concurrent stop() sees the updated flag immediately
+    isRunning = true
     Task { @MainActor [weak self] in
       guard let self else { return }
-      await self.streamSessionVM.handleStartStreaming()
-      self.isRunning = true
-      self.setupSession()
+      let started = await self.streamSessionVM.handleStartStreaming()
+      // Re-check isRunning: stop() may have been called while we were awaiting permission
+      guard self.isRunning else {
+        if started { await self.streamSessionVM.stopStreaming() }
+        return
+      }
+      if started {
+        self.setupSession()
+      } else {
+        self.isRunning = false
+      }
     }
   }
 
   func stop() {
     guard isRunning else { return }
+    // Set synchronously so a concurrent start() Task sees the updated flag after its await
+    isRunning = false
+    frameObservationTask?.cancel()
+    frameObservationTask = nil
     Task { @MainActor [weak self] in
-      guard let self else { return }
-      await self.streamSessionVM.stopStreaming()
-      self.frameObservationTask?.cancel()
-      self.frameObservationTask = nil
-      self.isRunning = false
+      await self?.streamSessionVM.stopStreaming()
     }
   }
 
-}
-
-// MARK: - UIImage to CVPixelBuffer conversion
-
-extension UIImage {
-  fileprivate func pixelBuffer() -> CVPixelBuffer? {
-    guard let cgImage = self.cgImage else { return nil }
-    let width = cgImage.width
-    let height = cgImage.height
-
-    let attrs =
-      [
-        kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue!,
-        kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue!,
-      ] as CFDictionary
-
-    var pixelBuffer: CVPixelBuffer?
-    let status = CVPixelBufferCreate(
-      kCFAllocatorDefault,
-      width,
-      height,
-      kCVPixelFormatType_32ARGB,
-      attrs,
-      &pixelBuffer
-    )
-
-    guard status == kCVReturnSuccess, let buffer = pixelBuffer else { return nil }
-
-    CVPixelBufferLockBaseAddress(buffer, [])
-    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
-
-    guard
-      let context = CGContext(
-        data: CVPixelBufferGetBaseAddress(buffer),
-        width: width,
-        height: height,
-        bitsPerComponent: 8,
-        bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
-        space: CGColorSpaceCreateDeviceRGB(),
-        bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
-      )
-    else { return nil }
-
-    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-    return buffer
-  }
 }

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -2,24 +2,15 @@
  * MetaGlassesFrameProvider.swift
  *
  * FrameProvider implementation for Meta glasses using the DAT SDK.
- * Uses MockDevice for testing without physical glasses.
+ *
+ * Lightweight adapter that delegates to StreamSessionViewModel.
+ * Responsibility: forward frames from the view model to the FrameProviderDelegate.
  */
 
 import CoreMedia
 import MWDATCamera
 import MWDATCore
 import UIKit
-
-#if DEBUG && canImport(MWDATMockDevice)
-  import MWDATMockDevice
-#endif
-
-/// Configuration for the mock video source used when testing without physical glasses.
-/// Change `mockVideoFileName` and `mockVideoFileExtension` to use a different video file.
-enum MetaGlassesConfig {
-  static let mockVideoFileName = "videoplayback.hevc"
-  static let mockVideoFileExtension = "mp4"
-}
 
 final class MetaGlassesFrameProvider: NSObject, FrameProvider {
 
@@ -29,27 +20,26 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   weak var delegate: FrameProviderDelegate?
   let sourceType: CaptureSourceType = .metaGlasses
   private(set) var isRunning: Bool = false
-  private var isStarting: Bool = false
 
-  // MARK: - Meta DAT SDK
+  // MARK: - Private
 
-  private var streamSession: StreamSession?
-  private var deviceSelector: AutoDeviceSelector?
-  private var stateListenerToken: AnyListenerToken?
-  private var videoFrameListenerToken: AnyListenerToken?
-  private var errorListenerToken: AnyListenerToken?
+  private let streamSessionVM: StreamSessionViewModel
+  private var frameObservationTask: Task<Void, Never>?
 
-  // Preview layer for displaying video
   private let previewImageView: UIImageView = {
-    let imageView = UIImageView()
-    imageView.contentMode = .scaleAspectFill
-    imageView.clipsToBounds = true
-    return imageView
+    let iv = UIImageView()
+    iv.contentMode = .scaleAspectFill
+    iv.clipsToBounds = true
+    return iv
   }()
 
   // MARK: - Init
 
-  override init() {
+  init(
+    streamSessionViewModel: StreamSessionViewModel = MetaGlassesEnvironment.shared
+      .streamSessionViewModel
+  ) {
+    self.streamSessionVM = streamSessionViewModel
     super.init()
     previewView.addSubview(previewImageView)
     previewImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -62,184 +52,94 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
   }
 
   deinit {
-    // Clean up stream session
-    Task { @MainActor [streamSession] in
-      await streamSession?.stop()
-    }
+    frameObservationTask?.cancel()
   }
 
   // MARK: - FrameProvider Methods
 
   func setupSession() {
-    guard streamSession == nil else { return }
-
-    // Must be called on MainActor for MWDATCamera
-    Task { @MainActor in
-      self.setupSessionOnMain()
-    }
-  }
-
-  @MainActor
-  private func setupSessionOnMain() {
-    guard streamSession == nil else { return }
-
-    let wearables = Wearables.shared
-    deviceSelector = AutoDeviceSelector(wearables: wearables)
-
-    let config = StreamSessionConfig(
-      videoCodec: .raw,
-      resolution: .low,
-      frameRate: 24
-    )
-
-    guard let selector = deviceSelector else {
-      print("[MetaGlassesFrameProvider] Failed to create device selector")
-      return
-    }
-    streamSession = StreamSession(streamSessionConfig: config, deviceSelector: selector)
-
-    // Subscribe to video frames
-    videoFrameListenerToken = streamSession?.videoFramePublisher.listen { [weak self] videoFrame in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
-        self.handleVideoFrame(videoFrame)
-      }
-    }
-
-    // Subscribe to state changes
-    stateListenerToken = streamSession?.statePublisher.listen { [weak self] state in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
-        switch state {
-        case .streaming:
-          self.isRunning = true
-          MetaGlassesManager.shared.isStreamActive = true
-          MetaGlassesManager.shared.streamStartFailed = false
-        case .stopped, .paused:
-          self.isRunning = false
-          MetaGlassesManager.shared.isStreamActive = false
-        case .waitingForDevice:
-          MetaGlassesManager.shared.isStreamActive = false
-        default:
-          break
+    // Start observing frames from the view model
+    frameObservationTask?.cancel()
+    frameObservationTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      while !Task.isCancelled {
+        if let frame = self.streamSessionVM.currentVideoFrame {
+          self.previewImageView.image = frame
+          // Convert UIImage back to CVPixelBuffer for the delegate
+          if let pixelBuffer = frame.pixelBuffer() {
+            self.delegate?.processFrame(self, buffer: pixelBuffer, depthAt: { _ in nil })
+          }
         }
+        try? await Task.sleep(nanoseconds: 33_000_000)  // ~30fps polling
       }
     }
-
-    // Subscribe to errors
-    errorListenerToken = streamSession?.errorPublisher.listen { _ in }
   }
 
   func start() {
-    guard !isRunning, !isStarting else { return }
-    isStarting = true
-
+    guard !isRunning else { return }
     Task { @MainActor [weak self] in
       guard let self else { return }
-      defer { self.isStarting = false }
-
-      // Reset failure flag for fresh attempt
-      MetaGlassesManager.shared.streamStartFailed = false
-
-      // Ensure session is set up before starting
-      if self.streamSession == nil {
-        self.setupSessionOnMain()
-      }
-
-      // Wait briefly for devices to become available if needed
-      var devices = Wearables.shared.devices
-      if devices.isEmpty {
-        try? await Task.sleep(nanoseconds: 500_000_000)
-        devices = Wearables.shared.devices
-      }
-
-      if !devices.isEmpty {
-        // Check and request permissions
-        do {
-          let permission = Permission.camera
-
-          var needsRequest = false
-          do {
-            let status = try await Wearables.shared.checkPermissionStatus(permission)
-            needsRequest = (status != .granted)
-          } catch {
-            needsRequest = true
-          }
-
-          if needsRequest {
-            MetaGlassesManager.shared.isPermissionRequestInProgress = true
-            let requestStatus = try await Wearables.shared.requestPermission(permission)
-            MetaGlassesManager.shared.isPermissionRequestInProgress = false
-            if requestStatus != .granted {
-              MetaGlassesManager.shared.isStreamActive = false
-              MetaGlassesManager.shared.streamStartFailed = true
-              MetaGlassesManager.shared.errorMessage =
-                "Camera permission required. Please grant access in Meta AI app."
-              return
-            }
-          }
-        } catch {
-          MetaGlassesManager.shared.isPermissionRequestInProgress = false
-          MetaGlassesManager.shared.isStreamActive = false
-          MetaGlassesManager.shared.streamStartFailed = true
-          MetaGlassesManager.shared.errorMessage =
-            "Camera permission required. Please grant access in Meta AI app."
-          return
-        }
-      } else {
-        MetaGlassesManager.shared.isStreamActive = false
-        MetaGlassesManager.shared.streamStartFailed = true
-        return
-      }
-
-      // Start the session
-      guard self.streamSession != nil else { return }
-      await self.streamSession?.start()
+      await self.streamSessionVM.handleStartStreaming()
+      self.isRunning = true
+      self.setupSession()
     }
   }
 
   func stop() {
-    guard isRunning || isStarting || streamSession != nil else { return }
-
-    Task { @MainActor in
-      await self.teardownSession()
+    guard isRunning else { return }
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      await self.streamSessionVM.stopStreaming()
+      self.frameObservationTask?.cancel()
+      self.frameObservationTask = nil
+      self.isRunning = false
     }
   }
 
-  @MainActor
-  private func teardownSession() async {
-    await streamSession?.stop()
+}
 
-    // Clear listener tokens
-    stateListenerToken = nil
-    videoFrameListenerToken = nil
-    errorListenerToken = nil
+// MARK: - UIImage to CVPixelBuffer conversion
 
-    // Clear session so a fresh one is created on next start
-    streamSession = nil
-    deviceSelector = nil
+extension UIImage {
+  fileprivate func pixelBuffer() -> CVPixelBuffer? {
+    guard let cgImage = self.cgImage else { return nil }
+    let width = cgImage.width
+    let height = cgImage.height
 
-    isRunning = false
-    MetaGlassesManager.shared.isStreamActive = false
-  }
+    let attrs =
+      [
+        kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue!,
+        kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue!,
+      ] as CFDictionary
 
-  // MARK: - Video Frame Handling
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_32ARGB,
+      attrs,
+      &pixelBuffer
+    )
 
-  private var frameCount = 0
+    guard status == kCVReturnSuccess, let buffer = pixelBuffer else { return nil }
 
-  @MainActor
-  private func handleVideoFrame(_ videoFrame: VideoFrame) {
-    frameCount += 1
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
 
-    // Update preview
-    if let uiImage = videoFrame.makeUIImage() {
-      previewImageView.image = uiImage
-    }
+    guard
+      let context = CGContext(
+        data: CVPixelBufferGetBaseAddress(buffer),
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
+      )
+    else { return nil }
 
-    // Convert to CVPixelBuffer and send to delegate
-    let sampleBuffer = videoFrame.sampleBuffer
-    if let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-      delegate?.processFrame(self, buffer: pixelBuffer, depthAt: { _ in nil })
-    }
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return buffer
   }
 }

--- a/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
+++ b/thing-finder/FramePublishers/MetaGlassesFrameProvider.swift
@@ -105,8 +105,11 @@ final class MetaGlassesFrameProvider: NSObject, FrameProvider {
     isRunning = false
     frameObservationTask?.cancel()
     frameObservationTask = nil
+    // Capture the current generation so the stop is skipped if a new provider
+    // calls startStreaming() before this async task executes.
+    let gen = streamSessionVM.streamGeneration
     Task { @MainActor [weak self] in
-      await self?.streamSessionVM.stopStreaming()
+      await self?.streamSessionVM.stopStreaming(ifGeneration: gen)
     }
   }
 

--- a/thing-finder/Services/MetaGlasses/MetaGlassesEnvironment.swift
+++ b/thing-finder/Services/MetaGlasses/MetaGlassesEnvironment.swift
@@ -1,0 +1,23 @@
+//
+//  MetaGlassesEnvironment.swift
+//  thing-finder
+//
+//  Shared container for WearablesViewModel and StreamSessionViewModel so both
+//  SwiftUI views and UIKit-based FrameProviders can access the same instances.
+//
+
+import MWDATCore
+import SwiftUI
+
+@MainActor
+final class MetaGlassesEnvironment: ObservableObject {
+  static let shared = MetaGlassesEnvironment()
+
+  let wearablesViewModel: WearablesViewModel
+  let streamSessionViewModel: StreamSessionViewModel
+
+  private init() {
+    self.wearablesViewModel = WearablesViewModel(wearables: Wearables.shared)
+    self.streamSessionViewModel = StreamSessionViewModel(wearables: Wearables.shared)
+  }
+}

--- a/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
+++ b/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
@@ -4,9 +4,18 @@
 //
 //  Singleton manager for Meta Ray-Ban glasses SDK lifecycle and connection state.
 //
+//  Architecture: single `GlassesState` enum is the source of truth.
+//  All published booleans are derived — never set independently.
+//
+//  State machine:
+//    unconfigured → idle → registering → registered → requestingPermission → ready → streaming
+//                                                                                  ↘ failed(reason)
+//                   ↑____________________________↙  (on unregistration)
+//
 
 import Combine
 import Foundation
+import MWDATCamera
 import MWDATCore
 import SwiftUI
 
@@ -14,108 +23,177 @@ import SwiftUI
   import MWDATMockDevice
 #endif
 
+// MARK: - State Machine
+
+/// Every possible state the Meta glasses integration can be in.
+/// Eliminates impossible state combinations that scattered booleans allow.
+public enum GlassesState: Equatable {
+  /// Wearables.configure() has not been called or failed.
+  case unconfigured
+  /// SDK configured but not registered with Meta AI.
+  case idle
+  /// Registration flow in progress (app may leave to Meta AI).
+  case registering
+  /// Registered with Meta AI, waiting for user to start streaming.
+  case registered
+  /// Camera permission request is in flight (app may leave to Meta AI).
+  case requestingPermission
+  /// Permission granted, ready to stream (or streaming hasn't started yet).
+  case ready
+  /// Actively streaming frames from glasses.
+  case streaming
+  /// A recoverable failure occurred; message explains why.
+  case failed(String)
+}
+
 @MainActor
 public final class MetaGlassesManager: ObservableObject {
   public static let shared = MetaGlassesManager()
 
-  @Published public var isConfigured: Bool = false
-  @Published public var isRegistered: Bool = false
-  @Published public var availableDevices: [DeviceIdentifier] = []
+  // MARK: - Single source of truth
+
+  @Published public private(set) var state: GlassesState = .unconfigured
+
+  // MARK: - Supplementary published state (not booleans about lifecycle)
+
+  @Published public private(set) var availableDevices: [DeviceIdentifier] = []
   @Published public var hasMockDevice: Bool = false
-  @Published public var errorMessage: String?
-  @Published public var isRegistrationInProgress: Bool = false
 
-  /// Tracks if registration was ever successful in this session (to handle SDK state flipping)
-  @Published public var hasEverRegistered: Bool = false
-
-  /// Set to true when registration completes via URL callback - triggers showing success modal
+  /// One-shot flag: set when registration completes via URL callback.
+  /// Views observe this to show a success modal, then reset it.
   @Published public var shouldShowRegistrationSuccess: Bool = false
 
-  /// Tracks if the glasses stream is currently active and producing frames
-  @Published public var isStreamActive: Bool = false
+  // MARK: - Derived convenience (read-only)
 
-  /// Tracks if the stream failed to start (e.g., permission denied) - triggers fallback
-  @Published public var streamStartFailed: Bool = false
+  /// True when glasses are usable as a camera source (permission granted).
+  public var isReady: Bool {
+    switch state {
+    case .ready, .streaming: return true
+    default: return false
+    }
+  }
 
-  /// Tracks if permission request is in progress (app may go to background for Meta AI)
-  @Published public var isPermissionRequestInProgress: Bool = false
+  /// True when the stream is actively producing frames.
+  public var isStreaming: Bool { state == .streaming }
 
+  /// True during flows that leave the app (registration or permission request).
+  public var isAwaitingExternalFlow: Bool {
+    switch state {
+    case .registering, .requestingPermission: return true
+    default: return false
+    }
+  }
+
+  /// True when registered (or better) with Meta AI.
+  public var isRegistered: Bool {
+    switch state {
+    case .registered, .requestingPermission, .ready, .streaming: return true
+    default: return false
+    }
+  }
+
+  /// Whether the capture source should fall back to the phone camera.
+  /// True when in a failed state or not yet ready.
+  public var shouldFallback: Bool {
+    if case .failed = state { return true }
+    return false
+  }
+
+  /// User-facing error message, derived from failed state.
+  public var errorMessage: String? {
+    if case .failed(let msg) = state { return msg }
+    return nil
+  }
+
+  // MARK: - Private
+
+  /// Tracks whether we came through the registration flow (vs. app relaunch with persisted state).
+  private var didInitiateRegistration = false
+  /// Persists camera permission grant across app launches so we don't re-request.
+  /// Cleared on unregistration.
+  @AppStorage("meta_glasses_permission_granted") var permissionGranted: Bool = false
   private var registrationTask: Task<Void, Never>?
   private var deviceStreamTask: Task<Void, Never>?
 
+  // MARK: - Init
+
   private init() {
-    setupWearables()
+    configureSDK()
   }
 
-  private func setupWearables() {
+  // MARK: - SDK Configuration
+
+  private func configureSDK() {
     do {
       try Wearables.configure()
-      isConfigured = true
-
-      // Check current registration state synchronously on launch
-      // This handles the case where the app relaunches with persisted registration
-      let currentState = Wearables.shared.registrationState
-      // print("[MetaGlassesManager] Initial registration state: \(currentState)")
-      handleRegistrationState(currentState, isInitial: true)
-
-      // Listen for future registration state changes
-      registrationTask = Task {
-        for await state in Wearables.shared.registrationStateStream() {
-          // print("[MetaGlassesManager] Registration state changed: \(state)")
-          self.handleRegistrationState(state, isInitial: false)
-        }
-      }
     } catch {
-      errorMessage = "Failed to configure Wearables SDK: \(error)"
-      // print("[MetaGlassesManager] \(errorMessage!)")
+      state = .failed("Failed to configure Wearables SDK: \(error.localizedDescription)")
+      return
+    }
+
+    // Check persisted registration state from a previous session
+    let currentState = Wearables.shared.registrationState
+    handleSDKRegistrationState(currentState, isInitial: true)
+
+    // Listen for future registration state changes
+    registrationTask = Task { [weak self] in
+      guard let self else { return }
+      for await sdkState in Wearables.shared.registrationStateStream() {
+        self.handleSDKRegistrationState(sdkState, isInitial: false)
+      }
     }
   }
 
-  private func handleRegistrationState(_ state: RegistrationState, isInitial: Bool) {
-    self.isRegistered = (state == .registered)
-
-    switch state {
+  /// Maps SDK RegistrationState → our GlassesState.
+  private func handleSDKRegistrationState(_ sdkState: RegistrationState, isInitial: Bool) {
+    switch sdkState {
     case .registered:
-      // If we were in registration flow (not initial), show success modal
-      if self.isRegistrationInProgress && !isInitial {
-        self.shouldShowRegistrationSuccess = true
+      // If we actively initiated registration (not a relaunch), show success
+      if didInitiateRegistration && !isInitial {
+        shouldShowRegistrationSuccess = true
       }
-      self.hasEverRegistered = true
-      self.isRegistrationInProgress = false
-      // Immediately fetch current devices synchronously to avoid race condition
-      self.availableDevices = Wearables.shared.devices
-      Task {
-        await self.setupDeviceStream()
+      didInitiateRegistration = false
+      availableDevices = Wearables.shared.devices
+      // Move to registered; streaming will be started by the FrameProvider
+      if permissionGranted {
+        state = .ready
+      } else {
+        state = .registered
       }
-    // print("[MetaGlassesManager] isReadyForUse: \(self.isReadyForUse)")
+      startDeviceStream()
 
     case .registering:
-      self.isRegistrationInProgress = true
-
-    default:
-      // Any state other than registered/registering means unregistered
-      self.hasEverRegistered = false
-      self.isRegistrationInProgress = false
-      self.isPermissionRequestInProgress = false
-      self.isStreamActive = false
-      self.streamStartFailed = false
-      self.availableDevices = []
-      self.deviceStreamTask?.cancel()
-      self.deviceStreamTask = nil
-    // print("[MetaGlassesManager] State \(state) - state reset")
+      state = .registering
+    case .unavailable:
+      resetToIdle(clearPermission: true)
+    case .available:
+      resetToIdle(clearPermission: false)
+    @unknown default:
+      resetToIdle(clearPermission: false)
     }
   }
 
-  private func setupDeviceStream() async {
-    // Immediately check current devices
-    self.availableDevices = Wearables.shared.devices
-    // print("[MetaGlassesManager] Initial devices: \(self.availableDevices)")
+  private func resetToIdle(clearPermission: Bool) {
+    state = .idle
+    if clearPermission {
+      permissionGranted = false
+    }
+    didInitiateRegistration = false
+    availableDevices = []
+    deviceStreamTask?.cancel()
+    deviceStreamTask = nil
+  }
+
+  // MARK: - Device Discovery
+
+  private func startDeviceStream() {
+    availableDevices = Wearables.shared.devices
 
     deviceStreamTask?.cancel()
-    deviceStreamTask = Task {
+    deviceStreamTask = Task { [weak self] in
+      guard let self else { return }
       for await devices in Wearables.shared.devicesStream() {
         self.availableDevices = devices
-        print("[MetaGlassesManager] Devices updated: \(devices)")
         #if DEBUG && canImport(MWDATMockDevice)
           self.hasMockDevice = !MockDeviceKit.shared.pairedDevices.isEmpty
         #endif
@@ -123,69 +201,135 @@ public final class MetaGlassesManager: ObservableObject {
     }
   }
 
+  // MARK: - Public Actions
+
+  /// Start the registration flow with Meta AI.
   public func connectGlasses() {
-    errorMessage = nil
-    guard isConfigured else {
-      errorMessage = "Wearables SDK not configured"
-      return
-    }
-    guard Wearables.shared.registrationState != .registering else { return }
+    guard case .idle = state else { return }
+
+    didInitiateRegistration = true
+    state = .registering
 
     Task {
       do {
         try await Wearables.shared.startRegistration()
+      } catch let error as RegistrationError {
+        state = .failed("Registration failed: \(error.description)")
       } catch {
-        self.errorMessage = "Failed to start registration: \(error)"
+        state = .failed("Registration failed: \(error.localizedDescription)")
       }
     }
   }
 
+  /// Unregister from Meta AI.
   public func disconnectGlasses() {
     Task {
       do {
         try await Wearables.shared.startUnregistration()
+      } catch let error as UnregistrationError {
+        state = .failed("Disconnect failed: \(error.description)")
       } catch {
-        self.errorMessage = "Failed to disconnect: \(error)"
+        state = .failed("Disconnect failed: \(error.localizedDescription)")
       }
     }
   }
 
-  /// Returns true if glasses are registered and available for use
-  public var isReadyForUse: Bool {
-    return isRegistered && !availableDevices.isEmpty
+  /// Request camera permission from the Meta AI companion app.
+  /// Called by MetaGlassesFrameProvider before streaming.
+  /// Returns true if permission is granted.
+  ///
+  /// Note: `checkPermissionStatus` always throws PermissionError in developer mode
+  /// (MetaAppID = "0"), so we skip it and rely on our persisted flag instead.
+  /// `requestPermission` is only called on first-ever grant.
+  public func ensureCameraPermission() async -> Bool {
+    // Already granted (persisted across launches) — skip entirely
+    if permissionGranted {
+      if state != .ready && state != .streaming {
+        state = .ready
+      }
+      return true
+    }
+
+    guard isRegistered else { return false }
+
+    // First-time permission request — this will leave the app to Meta AI
+    state = .requestingPermission
+    do {
+      let status = try await Wearables.shared.requestPermission(.camera)
+      if status == .granted {
+        permissionGranted = true
+        state = .ready
+        return true
+      } else {
+        state = .failed("Camera permission denied. Grant access in the Meta AI app.")
+        return false
+      }
+    } catch {
+      state = .failed("Camera permission request failed: \(error.localizedDescription)")
+      return false
+    }
   }
+
+  /// Called by MetaGlassesFrameProvider when the stream session state changes.
+  public func reportStreamState(_ streamState: StreamSessionState) {
+    switch streamState {
+    case .streaming:
+      state = .streaming
+    case .stopped:
+      // Only go back to ready if we were streaming; don't overwrite a failure
+      if state == .streaming { state = .ready }
+    case .waitingForDevice:
+      if state == .streaming { state = .ready }
+    default:
+      break
+    }
+  }
+
+  /// Called by MetaGlassesFrameProvider when streaming fails to start (e.g. no devices).
+  public func reportStreamFailure(_ reason: String) {
+    state = .failed(reason)
+  }
+
+  /// Reset from a failed state back to the best available state.
+  /// Called when the user explicitly re-enables glasses mode.
+  public func resetFailure() {
+    guard case .failed = state else { return }
+    // Figure out where we actually are based on SDK state
+    let sdkState = Wearables.shared.registrationState
+    if sdkState == .registered {
+      if permissionGranted {
+        state = .ready
+      } else {
+        state = .registered
+      }
+    } else {
+      state = .idle
+    }
+  }
+
+  // MARK: - Mock Device Support
 
   #if DEBUG && canImport(MWDATMockDevice)
     public func addMockDevice() {
-      // Load video from bundle for mock streaming
       guard
         let videoURL = Bundle.main.url(
           forResource: MetaGlassesConfig.mockVideoFileName,
           withExtension: MetaGlassesConfig.mockVideoFileExtension)
       else {
-        errorMessage =
-          "Mock video file '\(MetaGlassesConfig.mockVideoFileName).\(MetaGlassesConfig.mockVideoFileExtension)' not found in bundle. Add it to the Xcode project."
-        print("[MetaGlassesManager] \(errorMessage!)")
+        state = .failed(
+          "Mock video file '\(MetaGlassesConfig.mockVideoFileName).\(MetaGlassesConfig.mockVideoFileExtension)' not found in bundle."
+        )
         return
       }
 
-      print("[MetaGlassesManager] Found mock video at: \(videoURL)")
-
-      // Create mock Ray-Ban Meta device (SDK is MainActor-isolated)
-      // Priority inversion warnings are internal to the SDK and unavoidable
       let mockDevice = MockDeviceKit.shared.pairRaybanMeta()
-
-      // Power on and unfold the device
       mockDevice.powerOn()
       mockDevice.unfold()
 
-      // Set the camera feed from video file
       let cameraKit = mockDevice.getCameraKit()
       Task {
         await cameraKit.setCameraFeed(fileURL: videoURL)
-        await MainActor.run { [weak self] in
-          self?.hasMockDevice = true
-        }
+        self.hasMockDevice = true
       }
     }
 

--- a/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
+++ b/thing-finder/Services/MetaGlasses/MetaGlassesManager.swift
@@ -124,12 +124,8 @@ public final class MetaGlassesManager: ObservableObject {
   // MARK: - SDK Configuration
 
   private func configureSDK() {
-    do {
-      try Wearables.configure()
-    } catch {
-      state = .failed("Failed to configure Wearables SDK: \(error.localizedDescription)")
-      return
-    }
+    // Wearables.configure() is called once at app startup in ThingFinderApp.init().
+    // Do not call it again here — the SDK must only be configured once.
 
     // Check persisted registration state from a previous session
     let currentState = Wearables.shared.registrationState

--- a/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
+++ b/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
@@ -5,6 +5,7 @@
 //  Mirrors the Meta CameraAccess sample StreamSessionViewModel.
 //
 
+import CoreMedia
 import MWDATCamera
 import MWDATCore
 import SwiftUI
@@ -12,13 +13,16 @@ import SwiftUI
 @MainActor
 final class StreamSessionViewModel: ObservableObject {
   @Published var currentVideoFrame: UIImage?
+  /// Zero-copy pixel buffer extracted directly from the SDK's CMSampleBuffer.
+  /// Prefer this over converting currentVideoFrame back to CVPixelBuffer.
+  private(set) var currentPixelBuffer: CVPixelBuffer?
   @Published var hasReceivedFirstFrame: Bool = false
   @Published var streamingStatus: StreamingStatus = .stopped
   @Published var showError: Bool = false
   @Published var errorMessage: String = ""
   @Published var hasActiveDevice: Bool = false
 
-  var isStreaming: Bool { streamingStatus != .stopped }
+  var isStreaming: Bool { streamingStatus == .streaming }
 
   @Published var capturedPhoto: UIImage?
   @Published var showPhotoPreview: Bool = false
@@ -61,6 +65,8 @@ final class StreamSessionViewModel: ObservableObject {
     videoFrameListenerToken = streamSession.videoFramePublisher.listen { [weak self] frame in
       Task { @MainActor [weak self] in
         guard let self else { return }
+        // Extract pixel buffer zero-copy before makeUIImage() discards the sample buffer
+        self.currentPixelBuffer = CMSampleBufferGetImageBuffer(frame.sampleBuffer)
         if let image = frame.makeUIImage() {
           self.currentVideoFrame = image
           if !self.hasReceivedFirstFrame {
@@ -89,22 +95,27 @@ final class StreamSessionViewModel: ObservableObject {
     updateStatus(from: streamSession.state)
   }
 
-  func handleStartStreaming() async {
+  /// Checks/requests camera permission and starts streaming if granted.
+  /// Returns `true` if streaming was successfully initiated, `false` on permission denial or error.
+  @discardableResult
+  func handleStartStreaming() async -> Bool {
     let permission = Permission.camera
     do {
       let status = try await wearables.checkPermissionStatus(permission)
       if status == .granted {
         await startStreaming()
-        return
+        return true
       }
       let requestStatus = try await wearables.requestPermission(permission)
       if requestStatus == .granted {
         await startStreaming()
-        return
+        return true
       }
       showErrorMessage("Permission denied")
+      return false
     } catch {
       showErrorMessage("Permission error: \(error.localizedDescription)")
+      return false
     }
   }
 
@@ -136,6 +147,7 @@ final class StreamSessionViewModel: ObservableObject {
       streamingStatus = .streaming
     case .stopped:
       currentVideoFrame = nil
+      currentPixelBuffer = nil
       streamingStatus = .stopped
     case .waitingForDevice, .starting, .stopping, .paused:
       streamingStatus = .waiting

--- a/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
+++ b/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
@@ -1,0 +1,177 @@
+//
+//  StreamSessionViewModel.swift
+//  thing-finder
+//
+//  Mirrors the Meta CameraAccess sample StreamSessionViewModel.
+//
+
+import MWDATCamera
+import MWDATCore
+import SwiftUI
+
+@MainActor
+final class StreamSessionViewModel: ObservableObject {
+  @Published var currentVideoFrame: UIImage?
+  @Published var hasReceivedFirstFrame: Bool = false
+  @Published var streamingStatus: StreamingStatus = .stopped
+  @Published var showError: Bool = false
+  @Published var errorMessage: String = ""
+  @Published var hasActiveDevice: Bool = false
+
+  var isStreaming: Bool { streamingStatus != .stopped }
+
+  @Published var capturedPhoto: UIImage?
+  @Published var showPhotoPreview: Bool = false
+
+  private let wearables: WearablesInterface
+  private let deviceSelector: AutoDeviceSelector
+  private let streamSession: StreamSession
+
+  private var stateListenerToken: AnyListenerToken?
+  private var videoFrameListenerToken: AnyListenerToken?
+  private var errorListenerToken: AnyListenerToken?
+  private var photoDataListenerToken: AnyListenerToken?
+  private var deviceMonitorTask: Task<Void, Never>?
+
+  init(wearables: WearablesInterface = Wearables.shared) {
+    self.wearables = wearables
+    self.deviceSelector = AutoDeviceSelector(wearables: wearables)
+    let config = StreamSessionConfig(
+      videoCodec: .raw,
+      resolution: .high,
+      frameRate: 30
+    )
+    self.streamSession = StreamSession(streamSessionConfig: config, deviceSelector: deviceSelector)
+
+    deviceMonitorTask = Task { [weak self] in
+      guard let self else { return }
+      for await device in deviceSelector.activeDeviceStream() {
+        await MainActor.run {
+          self.hasActiveDevice = device != nil
+        }
+      }
+    }
+
+    stateListenerToken = streamSession.statePublisher.listen { [weak self] state in
+      Task { @MainActor [weak self] in
+        self?.updateStatus(from: state)
+      }
+    }
+
+    videoFrameListenerToken = streamSession.videoFramePublisher.listen { [weak self] frame in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        if let image = frame.makeUIImage() {
+          self.currentVideoFrame = image
+          if !self.hasReceivedFirstFrame {
+            self.hasReceivedFirstFrame = true
+          }
+        }
+      }
+    }
+
+    errorListenerToken = streamSession.errorPublisher.listen { [weak self] error in
+      Task { @MainActor [weak self] in
+        self?.showErrorMessage(Self.format(error))
+      }
+    }
+
+    photoDataListenerToken = streamSession.photoDataPublisher.listen { [weak self] photoData in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        if let image = UIImage(data: photoData.data) {
+          self.capturedPhoto = image
+          self.showPhotoPreview = true
+        }
+      }
+    }
+
+    updateStatus(from: streamSession.state)
+  }
+
+  func handleStartStreaming() async {
+    let permission = Permission.camera
+    do {
+      let status = try await wearables.checkPermissionStatus(permission)
+      if status == .granted {
+        await startStreaming()
+        return
+      }
+      let requestStatus = try await wearables.requestPermission(permission)
+      if requestStatus == .granted {
+        await startStreaming()
+        return
+      }
+      showErrorMessage("Permission denied")
+    } catch {
+      showErrorMessage("Permission error: \(error.localizedDescription)")
+    }
+  }
+
+  func startStreaming() async {
+    await streamSession.start()
+  }
+
+  func stopStreaming() async {
+    await streamSession.stop()
+  }
+
+  func dismissError() {
+    showError = false
+    errorMessage = ""
+  }
+
+  func capturePhoto() {
+    streamSession.capturePhoto(format: .jpeg)
+  }
+
+  func dismissPhotoPreview() {
+    showPhotoPreview = false
+    capturedPhoto = nil
+  }
+
+  private func updateStatus(from state: StreamSessionState) {
+    switch state {
+    case .streaming:
+      streamingStatus = .streaming
+    case .stopped:
+      currentVideoFrame = nil
+      streamingStatus = .stopped
+    case .waitingForDevice, .starting, .stopping, .paused:
+      streamingStatus = .waiting
+    }
+  }
+
+  private func showErrorMessage(_ message: String) {
+    errorMessage = message
+    showError = true
+  }
+
+  deinit {
+    deviceMonitorTask?.cancel()
+    stateListenerToken = nil
+    videoFrameListenerToken = nil
+    errorListenerToken = nil
+    photoDataListenerToken = nil
+  }
+
+  private static func format(_ error: StreamSessionError) -> String {
+    switch error {
+    case .deviceNotFound: return "Device not found. Ensure your glasses are connected."
+    case .deviceNotConnected: return "Device disconnected. Check your Bluetooth connection."
+    case .timeout: return "Streaming timed out. Please try again."
+    case .videoStreamingError: return "Video streaming failed. Please try again."
+    case .permissionDenied: return "Camera permission denied. Grant access in the Meta AI app."
+    case .hingesClosed: return "Glasses hinges are closed. Open them to stream."
+    case .thermalCritical: return "Device is overheating. Streaming paused."
+    case .internalError: return "An internal streaming error occurred."
+    @unknown default: return "An unknown streaming error occurred."
+    }
+  }
+}
+
+enum StreamingStatus {
+  case streaming
+  case waiting
+  case stopped
+}

--- a/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
+++ b/thing-finder/Services/MetaGlasses/StreamSessionViewModel.swift
@@ -36,6 +36,9 @@ final class StreamSessionViewModel: ObservableObject {
   private var errorListenerToken: AnyListenerToken?
   private var photoDataListenerToken: AnyListenerToken?
   private var deviceMonitorTask: Task<Void, Never>?
+  /// Incremented on each startStreaming call; stopStreaming is a no-op if the
+  /// generation has advanced (prevents a stale stop from killing a new session).
+  private(set) var streamGeneration: Int = 0
 
   init(wearables: WearablesInterface = Wearables.shared) {
     self.wearables = wearables
@@ -120,10 +123,19 @@ final class StreamSessionViewModel: ObservableObject {
   }
 
   func startStreaming() async {
+    streamGeneration += 1
     await streamSession.start()
   }
 
-  func stopStreaming() async {
+  /// Stop the current streaming session.
+  /// - Parameter generation: If provided, the stop is skipped when the stream
+  ///   generation has advanced (meaning a newer `startStreaming` was issued
+  ///   after this stop was queued). Pass `nil` to stop unconditionally.
+  func stopStreaming(ifGeneration generation: Int? = nil) async {
+    if let generation, generation != streamGeneration {
+      // A new startStreaming() was called after this stop was queued — skip.
+      return
+    }
     await streamSession.stop()
   }
 

--- a/thing-finder/Services/MetaGlasses/WearablesViewModel.swift
+++ b/thing-finder/Services/MetaGlasses/WearablesViewModel.swift
@@ -1,0 +1,143 @@
+//
+//  WearablesViewModel.swift
+//  thing-finder
+//
+//  Mirrors the Meta CameraAccess sample WearablesViewModel.
+//
+
+import MWDATCore
+import SwiftUI
+
+#if DEBUG && canImport(MWDATMockDevice)
+  import MWDATMockDevice
+#endif
+
+@MainActor
+final class WearablesViewModel: ObservableObject {
+  @Published var devices: [DeviceIdentifier]
+  @Published var hasMockDevice: Bool
+  @Published var registrationState: RegistrationState
+  @Published var showGettingStartedSheet: Bool = false
+  @Published var showError: Bool = false
+  @Published var errorMessage: String = ""
+
+  private var registrationTask: Task<Void, Never>?
+  private var deviceStreamTask: Task<Void, Never>?
+  private var setupDeviceStreamTask: Task<Void, Never>?
+  private let wearables: WearablesInterface
+  private var compatibilityListenerTokens: [DeviceIdentifier: AnyListenerToken] = [:]
+
+  init(wearables: WearablesInterface = Wearables.shared) {
+    self.wearables = wearables
+    self.devices = wearables.devices
+    #if DEBUG && canImport(MWDATMockDevice)
+      self.hasMockDevice = !MockDeviceKit.shared.pairedDevices.isEmpty
+    #else
+      self.hasMockDevice = false
+    #endif
+    self.registrationState = wearables.registrationState
+
+    setupDeviceStreamTask = Task {
+      await setupDeviceStream()
+    }
+
+    registrationTask = Task { [weak self] in
+      guard let self else { return }
+      for await state in wearables.registrationStateStream() {
+        let previousState = self.registrationState
+        self.registrationState = state
+        if !self.showGettingStartedSheet && state == .registered && previousState == .registering {
+          self.showGettingStartedSheet = true
+        }
+      }
+    }
+  }
+
+  deinit {
+    registrationTask?.cancel()
+    deviceStreamTask?.cancel()
+    setupDeviceStreamTask?.cancel()
+  }
+
+  private func setupDeviceStream() async {
+    if let task = deviceStreamTask, !task.isCancelled {
+      task.cancel()
+    }
+
+    deviceStreamTask = Task { [weak self] in
+      guard let self else { return }
+      for await devices in wearables.devicesStream() {
+        self.devices = devices
+        #if DEBUG && canImport(MWDATMockDevice)
+          self.hasMockDevice = !MockDeviceKit.shared.pairedDevices.isEmpty
+        #endif
+        monitorDeviceCompatibility(devices: devices)
+      }
+    }
+  }
+
+  private func monitorDeviceCompatibility(devices: [DeviceIdentifier]) {
+    let deviceSet = Set(devices)
+    compatibilityListenerTokens = compatibilityListenerTokens.filter { deviceSet.contains($0.key) }
+
+    for deviceId in devices {
+      guard compatibilityListenerTokens[deviceId] == nil else { continue }
+      guard let device = wearables.deviceForIdentifier(deviceId) else { continue }
+
+      let deviceName = device.nameOrId()
+      let token = device.addCompatibilityListener { [weak self] compatibility in
+        guard let self else { return }
+        if compatibility == .deviceUpdateRequired {
+          Task { @MainActor in
+            self.showError("Device '\(deviceName)' requires an update to work with this app")
+          }
+        }
+      }
+      compatibilityListenerTokens[deviceId] = token
+    }
+  }
+
+  func connectGlasses() {
+    guard registrationState != .registering else { return }
+    Task { @MainActor in
+      do {
+        try await wearables.startRegistration()
+      } catch let error as RegistrationError {
+        showError(error.description)
+      } catch {
+        showError(error.localizedDescription)
+      }
+    }
+  }
+
+  func disconnectGlasses() {
+    Task { @MainActor in
+      do {
+        try await wearables.startUnregistration()
+      } catch let error as UnregistrationError {
+        showError(error.description)
+      } catch {
+        showError(error.localizedDescription)
+      }
+    }
+  }
+
+  func showError(_ message: String) {
+    errorMessage = message
+    showError = true
+  }
+
+  func dismissError() {
+    showError = false
+    errorMessage = ""
+  }
+}
+
+extension DeviceIdentifier {
+  fileprivate func nameOrId() -> String {
+    if let device = Wearables.shared.deviceForIdentifier(self) {
+      return device.name
+    }
+    return String(describing: self)
+  }
+}

--- a/thing-finder/Views/CameraPreviewView.swift
+++ b/thing-finder/Views/CameraPreviewView.swift
@@ -94,10 +94,6 @@ struct CameraPreviewView: UIViewControllerRepresentable {
         }
       }
     } else {
-      // Don't stop Meta glasses capture while permission request is in progress
-      if source == .metaGlasses && MetaGlassesManager.shared.isPermissionRequestInProgress {
-        return
-      }
       capture.stop()
     }
   }

--- a/thing-finder/Views/DetectorContainer.swift
+++ b/thing-finder/Views/DetectorContainer.swift
@@ -18,7 +18,11 @@ struct DetectorContainer: View {
 
   // MARK: – Dependencies
   @ObservedObject private var debugOverlayModel = AppContainer.shared.debugOverlayModel
-  @ObservedObject private var metaGlassesManager = MetaGlassesManager.shared
+  @EnvironmentObject private var wearablesVM: WearablesViewModel
+  @EnvironmentObject private var streamSessionVM: StreamSessionViewModel
+
+  // Track capture source as state so we can update it reactively
+  @State private var currentCaptureSource: CaptureSourceType = .avFoundation
 
   // MARK: – StateObject (lifetime tied to this view instance)
   @StateObject private var detectionModel: CameraViewModel
@@ -46,17 +50,16 @@ struct DetectorContainer: View {
 
   // MARK: - Computed Properties
 
-  /// Determines the capture source based on settings and Meta glasses availability
-  /// Falls back to phone camera if glasses mode is enabled but stream isn't active or failed
-  private var captureSource: CaptureSourceType {
-    if FeatureFlags.metaGlassesEnabled
-      && settings.useMetaGlasses
-      && !metaGlassesManager.streamStartFailed
-      && (metaGlassesManager.isStreamActive
-        || metaGlassesManager.isReadyForUse
-        || metaGlassesManager.isPermissionRequestInProgress)
-    {
-      return .metaGlasses
+  /// Determines the capture source based on settings and Meta glasses state.
+  /// Falls back to phone camera immediately on failure or when glasses aren't usable.
+  private func computeCaptureSource() -> CaptureSourceType {
+    if FeatureFlags.metaGlassesEnabled && settings.useMetaGlasses {
+      // Use glasses if registered AND (streaming or has an active device ready)
+      if wearablesVM.registrationState == .registered
+        && (streamSessionVM.isStreaming || streamSessionVM.hasActiveDevice)
+      {
+        return .metaGlasses
+      }
     }
     if settings.useARMode {
       return .arKit
@@ -71,7 +74,7 @@ struct DetectorContainer: View {
       CameraPreviewWrapper(
         isRunning: $isRunning,
         delegate: detectionModel,
-        source: captureSource
+        source: currentCaptureSource
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -100,6 +103,19 @@ struct DetectorContainer: View {
     }
     // Propagate orientation events so the model can react.
     .onRotate { _ in detectionModel.handleOrientationChange() }
-    .onAppear { detectionModel.handleOrientationChange() }
+    .onAppear {
+      detectionModel.handleOrientationChange()
+      currentCaptureSource = computeCaptureSource()
+    }
+    // Re-evaluate capture source when relevant states change
+    .onChange(of: wearablesVM.registrationState) { _, _ in
+      currentCaptureSource = computeCaptureSource()
+    }
+    .onChange(of: streamSessionVM.isStreaming) { _, _ in
+      currentCaptureSource = computeCaptureSource()
+    }
+    .onChange(of: streamSessionVM.hasActiveDevice) { _, _ in
+      currentCaptureSource = computeCaptureSource()
+    }
   }
 }

--- a/thing-finder/Views/InputView.swift
+++ b/thing-finder/Views/InputView.swift
@@ -77,6 +77,15 @@ struct InputView: View {
       saveToHistory(carDesc, mode: .uberFinder, paratransit: false)
       isShowingCamera = true
     }
+
+    if let paratransitDesc = shortcutNavigationState.consumePendingParatransitDescription() {
+      description = paratransitDesc
+      searchMode = .uberFinder
+      showPlaceholder = false
+      isParatransitMode = true
+      saveToHistory(paratransitDesc, mode: .uberFinder, paratransit: true)
+      isShowingCamera = true
+    }
   }
 
   var body: some View {
@@ -240,6 +249,11 @@ struct InputView: View {
         checkForShortcutNavigation()
       }
       .onChange(of: shortcutNavigationState.pendingCarDescription) { _, newValue in
+        if newValue != nil {
+          checkForShortcutNavigation()
+        }
+      }
+      .onChange(of: shortcutNavigationState.pendingParatransitDescription) { _, newValue in
         if newValue != nil {
           checkForShortcutNavigation()
         }

--- a/thing-finder/Views/MetaGlassesSettingsSection.swift
+++ b/thing-finder/Views/MetaGlassesSettingsSection.swift
@@ -114,12 +114,6 @@ struct MetaGlassesSettingsSection: View {
     .sheet(isPresented: $showingSetupSheet) {
       MetaGlassesSetupView()
     }
-    .sheet(isPresented: $wearablesVM.showGettingStartedSheet) {
-      MetaGlassesSuccessView()
-        .onDisappear {
-          wearablesVM.showGettingStartedSheet = false
-        }
-    }
   }
 
   private var disconnectButton: some View {

--- a/thing-finder/Views/MetaGlassesSettingsSection.swift
+++ b/thing-finder/Views/MetaGlassesSettingsSection.swift
@@ -5,11 +5,12 @@
 //  Settings section for Meta Ray-Ban glasses configuration.
 //
 
+import MWDATCore
 import SwiftUI
 
 struct MetaGlassesSettingsSection: View {
   @ObservedObject var settings: Settings
-  @StateObject private var manager = MetaGlassesManager.shared
+  @EnvironmentObject private var wearablesVM: WearablesViewModel
   @State private var showingSetupSheet = false
   @State private var showingSuccessSheet = false
 
@@ -23,53 +24,24 @@ struct MetaGlassesSettingsSection: View {
       if settings.useMetaGlasses {
         connectionStatusView
 
-        if manager.isRegistered || manager.hasEverRegistered {
+        if wearablesVM.registrationState == .registered {
           disconnectButton
         } else {
           connectButton
         }
 
         // Device count
-        if !manager.availableDevices.isEmpty {
-          Text("\(manager.availableDevices.count) device(s) available")
+        if !wearablesVM.devices.isEmpty {
+          Text("\(wearablesVM.devices.count) device(s) available")
             .font(.caption)
             .foregroundColor(.secondary)
-        }
-
-        #if DEBUG && canImport(MWDATMockDevice)
-          // Mock device controls for testing
-          Divider()
-          Text("Testing (Debug Only)")
-            .font(.caption)
-            .foregroundColor(.secondary)
-
-          if manager.hasMockDevice {
-            Button("Remove Mock Device") {
-              manager.removeMockDevice()
-            }
-            .foregroundColor(.orange)
-          } else {
-            Button("Add Mock Device") {
-              manager.addMockDevice()
-            }
-            Text("Uses bundled video file for testing without glasses.")
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-        #endif
-
-        // Error display
-        if let error = manager.errorMessage {
-          Text(error)
-            .font(.caption)
-            .foregroundColor(.red)
         }
       }
     }
-    .onChange(of: manager.shouldShowRegistrationSuccess) { _, shouldShow in
+    .onChange(of: wearablesVM.showGettingStartedSheet) { _, shouldShow in
       if shouldShow {
         showingSuccessSheet = true
-        manager.shouldShowRegistrationSuccess = false
+        wearablesVM.showGettingStartedSheet = false
       }
     }
     .sheet(isPresented: $showingSuccessSheet) {
@@ -80,18 +52,51 @@ struct MetaGlassesSettingsSection: View {
   // MARK: - Connection Status
 
   private var connectionStatusView: some View {
-    HStack {
-      Text("Status")
-      Spacer()
-      if manager.isRegistered || manager.hasEverRegistered {
-        Label("Connected", systemImage: "checkmark.circle.fill")
-          .foregroundColor(.green)
-      } else {
-        Label("Not Connected", systemImage: "xmark.circle")
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Circle()
+          .fill(statusColor)
+          .frame(width: 8, height: 8)
+        Text(statusText)
+          .font(.subheadline)
           .foregroundColor(.secondary)
       }
+
+      if wearablesVM.showError {
+        Text(wearablesVM.errorMessage)
+          .font(.caption)
+          .foregroundColor(.red)
+      }
     }
-    .padding(.top, 4)
+    .padding(.vertical, 4)
+  }
+
+  private var statusColor: Color {
+    switch wearablesVM.registrationState {
+    case .registered:
+      return .green
+    case .registering:
+      return .orange
+    case .available, .unavailable:
+      return .gray
+    @unknown default:
+      return .gray
+    }
+  }
+
+  private var statusText: String {
+    switch wearablesVM.registrationState {
+    case .registered:
+      return "Connected"
+    case .registering:
+      return "Connecting to Meta AI..."
+    case .available:
+      return "Available - not connected"
+    case .unavailable:
+      return "Not available"
+    @unknown default:
+      return "Unknown status"
+    }
   }
 
   // MARK: - Buttons
@@ -101,18 +106,25 @@ struct MetaGlassesSettingsSection: View {
       showingSetupSheet = true
     } label: {
       HStack {
-        Image(systemName: "eyeglasses")
+        Image(systemName: "link")
         Text("Connect Glasses")
       }
     }
+    .buttonStyle(.bordered)
     .sheet(isPresented: $showingSetupSheet) {
       MetaGlassesSetupView()
+    }
+    .sheet(isPresented: $wearablesVM.showGettingStartedSheet) {
+      MetaGlassesSuccessView()
+        .onDisappear {
+          wearablesVM.showGettingStartedSheet = false
+        }
     }
   }
 
   private var disconnectButton: some View {
     Button(role: .destructive) {
-      manager.disconnectGlasses()
+      wearablesVM.disconnectGlasses()
     } label: {
       HStack {
         Image(systemName: "xmark.circle")

--- a/thing-finder/Views/MetaGlassesSetupView.swift
+++ b/thing-finder/Views/MetaGlassesSetupView.swift
@@ -16,7 +16,7 @@ enum MetaGlassesSetupStep: Int, CaseIterable {
 
 struct MetaGlassesSetupView: View {
   @Environment(\.dismiss) private var dismiss
-  @StateObject private var manager = MetaGlassesManager.shared
+  @EnvironmentObject private var wearablesVM: WearablesViewModel
   @State private var currentStep: MetaGlassesSetupStep = .developerMode
 
   var body: some View {
@@ -48,27 +48,24 @@ struct MetaGlassesSetupView: View {
         }
       }
       .onAppear {
-        print(
-          "[MetaGlassesSetupView] onAppear - isRegistered: \(manager.isRegistered), hasEverRegistered: \(manager.hasEverRegistered), isRegistrationInProgress: \(manager.isRegistrationInProgress)"
-        )
-
         // Determine initial step based on current state
-        if manager.isRegistered || manager.hasEverRegistered {
+        switch wearablesVM.registrationState {
+        case .registered:
           currentStep = .success
-        } else if manager.isRegistrationInProgress {
+        case .registering:
           currentStep = .requestPermission
-        }
-        // Otherwise stay on developerMode (step 1)
-      }
-      .onChange(of: manager.isRegistered) { _, isRegistered in
-        print("[MetaGlassesSetupView] isRegistered changed to: \(isRegistered)")
-        if isRegistered {
-          currentStep = .success
+        default:
+          break  // Stay on developerMode (step 1)
         }
       }
-      .onChange(of: manager.hasEverRegistered) { _, hasEverRegistered in
-        if hasEverRegistered {
+      .onChange(of: wearablesVM.registrationState) { _, newState in
+        switch newState {
+        case .registered:
           currentStep = .success
+        case .registering:
+          currentStep = .requestPermission
+        default:
+          break
         }
       }
     }
@@ -133,27 +130,26 @@ struct MetaGlassesSetupView: View {
       .foregroundColor(.secondary)
 
       VStack(spacing: 16) {
-        if let errorMessage = manager.errorMessage {
+        if wearablesVM.showError {
           VStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
               .font(.largeTitle)
               .foregroundColor(.orange)
             Text("Connection Error")
               .font(.headline)
-            Text(errorMessage)
+            Text(wearablesVM.errorMessage)
               .font(.caption)
               .foregroundColor(.secondary)
               .multilineTextAlignment(.center)
 
-            // Allow retry after error
             Button("Try Again") {
-              manager.errorMessage = nil
-              manager.connectGlasses()
+              wearablesVM.dismissError()
+              wearablesVM.connectGlasses()
             }
             .buttonStyle(.bordered)
           }
           .padding()
-        } else if manager.isRegistrationInProgress {
+        } else if wearablesVM.registrationState == .registering {
           VStack(spacing: 12) {
             ProgressView()
               .scaleEffect(1.5)
@@ -167,7 +163,7 @@ struct MetaGlassesSetupView: View {
           .padding()
         } else {
           Button {
-            manager.connectGlasses()
+            wearablesVM.connectGlasses()
           } label: {
             HStack {
               Image(systemName: "link")


### PR DESCRIPTION
## Summary

- **`isStreaming` fix**: now only `true` when actually `.streaming`, not during `.waiting` states — prevents blank camera view when glasses are in `waitingForDevice`/`paused`
- **Start/stop race fix**: `isRunning` is now set synchronously in `start()`/`stop()` so concurrent calls see consistent state; `handleStartStreaming()` returns a `Bool` to detect permission failure and avoid entering a broken "running but no frames" state
- **Zero-copy frame delivery**: `StreamSessionViewModel` now exposes `currentPixelBuffer` extracted directly from `CMSampleBuffer` via `CMSampleBufferGetImageBuffer` — removes the expensive UIImage→CVPixelBuffer `CGContext` round-trip (~3.7MB alloc per frame at 30fps)
- **Duplicate frame skip**: polling loop tracks `lastFrameRef` and skips conversion when the frame hasn't changed
- **Source switch race fix**: generation counter on `StreamSessionViewModel` prevents a stale async `stopStreaming()` from an old provider killing a session started by a new provider on reconnect
- **`MetaGlassesManager` dead code**: removed redundant `Wearables.configure()` call; SDK is already configured once at app startup
- **Duplicate sheet presentation**: removed conflicting `.sheet(isPresented: $wearablesVM.showGettingStartedSheet)` binding on `connectButton` that competed with the `.onChange` handler
- **Workspace cleanup**: removed local developer filesystem path from `thing-finder.code-workspace`

## Test plan

- [ ] Glasses connected at launch → camera switches to glasses source
- [ ] Glasses disconnected mid-session → falls back to AVFoundation immediately
- [ ] Glasses reconnected → switches back to glasses source
- [ ] Permission denied flow → app does not enter broken "isRunning but no frames" state
- [ ] No duplicate ML inference on static scenes (CPU should drop when nothing moves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)