### PR TITLE
Telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ results/*
 thing-finder/Secrets.xcconfig
 **.JPG
 **.mp4
+**/node_modules/**
+**/.next/**

--- a/thing-finder.xcodeproj/project.pbxproj
+++ b/thing-finder.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		311C9CEF2F9001AA001CAD5F /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 311C9CEE2F9001AA001CAD5F /* PostHog */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		3106F9122E2C3DBD00A9092B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -59,6 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				311C9CEF2F9001AA001CAD5F /* PostHog in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,6 +131,7 @@
 			);
 			name = "thing-finder";
 			packageProductDependencies = (
+				311C9CEE2F9001AA001CAD5F /* PostHog */,
 			);
 			productName = "thing-finder";
 			productReference = 313783A42DF497B200C36BEE /* thing-finder.app */;
@@ -160,6 +166,7 @@
 			mainGroup = 3137839B2DF497B200C36BEE;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				311C9CED2F9001AA001CAD5F /* XCRemoteSwiftPackageReference "posthog-ios" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 313783A52DF497B200C36BEE /* Products */;
@@ -484,6 +491,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		311C9CED2F9001AA001CAD5F /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PostHog/posthog-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.50.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		311C9CEE2F9001AA001CAD5F /* PostHog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 311C9CED2F9001AA001CAD5F /* XCRemoteSwiftPackageReference "posthog-ios" */;
+			productName = PostHog;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3137839C2DF497B200C36BEE /* Project object */;
 }

--- a/thing-finder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/thing-finder.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "a2fc303e4b16c93c972ef2ddc4042cf91a9400e5d1639bc9740a80c0336cdd4e",
+  "pins" : [
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
+        "version" : "1.12.2"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "19d0df316c68ff2e806eaa73563e7fb79788f978",
+        "version" : "3.50.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/thing-finder/App/App.swift
+++ b/thing-finder/App/App.swift
@@ -20,6 +20,7 @@ struct ThingFinderApp: App {
         rawValue: UserDefaults.standard.string(forKey: "app_language")
           ?? SupportedLanguage.system.rawValue) ?? .system
     LanguageManager.applyLanguage(language)
+    TelemetryService.shared.configure(settings: Settings())
 
     // COMMENTED OUT FOR APP STORE SUBMISSION
     // Configure Wearables SDK on launch (matches Meta sample pattern)
@@ -37,6 +38,10 @@ struct ThingFinderApp: App {
         .environment(\.locale, LanguageManager.locale(for: appLanguage))
         .onChange(of: appLanguageRaw) { _, newValue in
           LanguageManager.applyLanguage(SupportedLanguage(rawValue: newValue) ?? .system)
+        }
+        .onChange(of: sharedSettings.telemetryConsentRaw) { _, _ in
+          // Re-configure so TelemetryService sees the updated consent state
+          TelemetryService.shared.configure(settings: sharedSettings)
         }
       // COMMENTED OUT FOR APP STORE SUBMISSION
       // .environmentObject(glassesEnvironment.wearablesViewModel)
@@ -104,6 +109,10 @@ struct MainTabView: View {
     Bool = false
   @EnvironmentObject var sharedSettings: Settings
 
+  private var showTelemetryConsent: Bool {
+    hasAcceptedExperimentalDisclaimer && sharedSettings.telemetryConsent == .notAsked
+  }
+
   var body: some View {
     TabView {
       NavigationStack {
@@ -136,6 +145,17 @@ struct MainTabView: View {
     ) {
       ExperimentalDisclaimerView(
         hasAcceptedExperimentalDisclaimer: $hasAcceptedExperimentalDisclaimer
+      )
+    }
+    .fullScreenCover(
+      isPresented: Binding(
+        get: { showTelemetryConsent },
+        set: { _ in }
+      )
+    ) {
+      TelemetryConsentView(
+        onAccept: { sharedSettings.telemetryConsent = .accepted },
+        onDecline: { sharedSettings.telemetryConsent = .declined }
       )
     }
   }

--- a/thing-finder/App/App.swift
+++ b/thing-finder/App/App.swift
@@ -20,7 +20,8 @@ struct ThingFinderApp: App {
         rawValue: UserDefaults.standard.string(forKey: "app_language")
           ?? SupportedLanguage.system.rawValue) ?? .system
     LanguageManager.applyLanguage(language)
-    TelemetryService.shared.configure(settings: Settings())
+    // PostHog SDK setup is deferred until consent is accepted
+    // (see TelemetryService.setupSDKIfConsented).
 
     // COMMENTED OUT FOR APP STORE SUBMISSION
     // Configure Wearables SDK on launch (matches Meta sample pattern)
@@ -40,8 +41,10 @@ struct ThingFinderApp: App {
           LanguageManager.applyLanguage(SupportedLanguage(rawValue: newValue) ?? .system)
         }
         .onChange(of: sharedSettings.telemetryConsentRaw) { _, _ in
-          // Re-configure so TelemetryService sees the updated consent state
-          TelemetryService.shared.configure(settings: sharedSettings)
+          // Attempt SDK setup now that consent may have changed.
+          // setupSDKIfConsented reads consent directly from UserDefaults
+          // and is a no-op if already configured or consent is not accepted.
+          TelemetryService.shared.setupSDKIfConsented()
         }
       // COMMENTED OUT FOR APP STORE SUBMISSION
       // .environmentObject(glassesEnvironment.wearablesViewModel)

--- a/thing-finder/App/App.swift
+++ b/thing-finder/App/App.swift
@@ -41,10 +41,9 @@ struct ThingFinderApp: App {
           LanguageManager.applyLanguage(SupportedLanguage(rawValue: newValue) ?? .system)
         }
         .onChange(of: sharedSettings.telemetryConsentRaw) { _, _ in
-          // Attempt SDK setup now that consent may have changed.
-          // setupSDKIfConsented reads consent directly from UserDefaults
-          // and is a no-op if already configured or consent is not accepted.
+          // Initialize SDK on first acceptance; opt in/out on subsequent changes.
           TelemetryService.shared.setupSDKIfConsented()
+          TelemetryService.shared.updateConsentState()
         }
       // COMMENTED OUT FOR APP STORE SUBMISSION
       // .environmentObject(glassesEnvironment.wearablesViewModel)

--- a/thing-finder/Core/Candidate.swift
+++ b/thing-finder/Core/Candidate.swift
@@ -142,6 +142,7 @@ public enum RejectReason: String, Codable {
   case lowConfidence = "low_confidence"
   case insufficientInfo = "insufficient_info"
   case apiError = "api_error"
+  case noVehicleDetected = "no_vehicle_detected"
   case ambiguous = "ambiguous"
   case licensePlateNotVisible = "license_plate_not_visible"
 
@@ -156,7 +157,7 @@ public enum RejectReason: String, Codable {
   /// Whether this reason should trigger a retry rather than a hard rejection
   public var isRetryable: Bool {
     switch self {
-    case .unclearImage, .lowConfidence, .insufficientInfo, .apiError, .ambiguous,
+    case .unclearImage, .lowConfidence, .insufficientInfo, .apiError, .noVehicleDetected, .ambiguous,
       .licensePlateNotVisible:
       return true
     default:
@@ -177,6 +178,9 @@ public enum RejectReason: String, Codable {
       return String(
         localized: "Need a better view", comment: "Reject reason: insufficient information")
     case .apiError: return String(localized: "Detection error", comment: "Reject reason: API error")
+    case .noVehicleDetected:
+      return String(
+        localized: "No vehicle in frame", comment: "Reject reason: TrafficEye found no vehicle in crop")
     case .ambiguous:
       return String(localized: "Ambiguous result", comment: "Reject reason: ambiguous detection")
     case .licensePlateNotVisible:

--- a/thing-finder/Info.plist
+++ b/thing-finder/Info.plist
@@ -6,5 +6,7 @@
 	<string>$(OPENAI_API)</string>
 	<key>TRAFFICEYE_API_KEY</key>
 	<string>$(TRAFFICEYE_API_KEY)</string>
+	<key>POSTHOG_API_KEY</key>
+	<string>$(POSTHOG_API_KEY)</string>
 </dict>
 </plist>

--- a/thing-finder/Localizable.xcstrings
+++ b/thing-finder/Localizable.xcstrings
@@ -72,6 +72,9 @@
         }
       }
     },
+    "•" : {
+
+    },
     "• **'Hey Siri, CurbToCar search'**" : {
       "localizations" : {
         "es" : {
@@ -271,6 +274,9 @@
         }
       }
     },
+    "Analytics" : {
+
+    },
     "Announce 'Waiting for verification' messages." : {
       "localizations" : {
         "es" : {
@@ -442,6 +448,9 @@
           }
         }
       }
+    },
+    "Can't make out the vehicle, retrying" : {
+      "comment" : "Speech: retry because TrafficEye found no vehicle in crop"
     },
     "Can't see the plate, retrying" : {
       "comment" : "Speech: retry due to plate not visible",
@@ -1253,6 +1262,12 @@
         }
       }
     },
+    "Help Improve CurbToCar" : {
+
+    },
+    "Helps improve the app. No personal information is collected." : {
+
+    },
     "How often the same direction is repeated." : {
       "localizations" : {
         "es" : {
@@ -1535,6 +1550,15 @@
           }
         }
       }
+    },
+    "No Thanks" : {
+
+    },
+    "No thanks, don't share data" : {
+
+    },
+    "No vehicle in frame" : {
+      "comment" : "Reject reason: TrafficEye found no vehicle in crop"
     },
     "No vehicles detected" : {
       "localizations" : {
@@ -1948,6 +1972,9 @@
         }
       }
     },
+    "Sends anonymous data about whether vehicles are found and where detection fails. No images, location, or license plate text is ever collected." : {
+
+    },
     "Settings" : {
       "localizations" : {
         "es" : {
@@ -1957,6 +1984,15 @@
           }
         }
       }
+    },
+    "Share Anonymous Data" : {
+
+    },
+    "Share anonymous usage data" : {
+
+    },
+    "Share Anonymous Usage Data" : {
+
     },
     "Shortest time between beeps/pulses when target is centered." : {
       "localizations" : {
@@ -2403,6 +2439,9 @@
         }
       }
     },
+    "We'd like to collect anonymous usage data to understand how well the app finds vehicles and where it falls short." : {
+
+    },
     "What are you looking for?" : {
       "localizations" : {
         "es" : {
@@ -2433,6 +2472,12 @@
         }
       }
     },
+    "What we collect:" : {
+
+    },
+    "What we never collect:" : {
+
+    },
     "Wrong make or model" : {
       "comment" : "Reject reason: wrong vehicle",
       "localizations" : {
@@ -2454,6 +2499,9 @@
           }
         }
       }
+    },
+    "You can change this at any time in Settings." : {
+
     },
     "Your Meta Ray-Ban glasses are now connected. The app will use the glasses camera when they are open and connected." : {
       "extractionState" : "stale",

--- a/thing-finder/Models/Settings.swift
+++ b/thing-finder/Models/Settings.swift
@@ -179,6 +179,23 @@ public class Settings: ObservableObject {
 
   /// Whether to use Meta glasses camera when available
   @AppStorage("use_meta_glasses") var useMetaGlasses: Bool = false
+
+  // MARK: - Telemetry Settings
+
+  /// Whether the user has responded to the analytics consent prompt.
+  @AppStorage("telemetry_consent") var telemetryConsentRaw: String = TelemetryConsent.notAsked.rawValue
+
+  var telemetryConsent: TelemetryConsent {
+    get { TelemetryConsent(rawValue: telemetryConsentRaw) ?? .notAsked }
+    set { telemetryConsentRaw = newValue.rawValue }
+  }
+}
+
+/// Whether the user has consented to anonymous usage analytics.
+enum TelemetryConsent: String {
+  case notAsked = "not_asked"
+  case accepted = "accepted"
+  case declined = "declined"
 }
 
 /// Volume curve types for distance mapping
@@ -350,6 +367,8 @@ extension Settings {
 
     // Language Settings
     appLanguageRaw = SupportedLanguage.system.rawValue
+
+    // Telemetry — preserve consent across resets (user's explicit choice)
     LanguageManager.applyLanguage(.system)
 
     // Force UserDefaults to synchronize changes

--- a/thing-finder/Services/Coordinator/FramePipelineCoordinator.swift
+++ b/thing-finder/Services/Coordinator/FramePipelineCoordinator.swift
@@ -41,6 +41,9 @@ public final class FramePipelineCoordinator: ObservableObject {
   private let targetClasses: [String]
   private let targetDescription: String
   private let settings: Settings
+
+  private var sessionFoundEmitted = false
+
   // MARK: Publishers
   @Published public private(set) var presentation: FramePresentation?
 
@@ -86,6 +89,10 @@ public final class FramePipelineCoordinator: ObservableObject {
         return targetClasses.contains(firstLabel.identifier)
       }, orientation: orientation)
 
+    if !detections.isEmpty {
+      TelemetryService.shared.recordFirstDetectionIfNeeded()
+    }
+
     // 2. Vision tracking updates existing candidates
     tracker.tick(pixelBuffer: pixelBuffer, orientation: orientation, store: store)
 
@@ -120,6 +127,11 @@ public final class FramePipelineCoordinator: ObservableObject {
     var machine = stateMachine
     machine.update(snapshot: Array(snapshot.values))
     let phase = machine.phase
+
+    if case .found = phase, !sessionFoundEmitted {
+      sessionFoundEmitted = true
+      TelemetryService.shared.markSessionFound()
+    }
 
     // 7.5 Determine target bounding box & approximate distance for navigation cues
     var targetBBox: CGRect?

--- a/thing-finder/Services/Pipeline/Verification/TrafficEyeVerifier.swift
+++ b/thing-finder/Services/Pipeline/Verification/TrafficEyeVerifier.swift
@@ -214,11 +214,11 @@ public final class TrafficEyeVerifier: ImageVerifier {
         }
 
         guard let mmr = result.mmr else {
-          // No vehicle detection at all
-          DebugPublisher.shared.error(
-            "[TrafficEye][\(candidateId.uuidString.suffix(8))] No vehicle MMR data in API response")
+          // API succeeded but found no recognizable vehicle in the crop — image quality issue, not an infra error
+          DebugPublisher.shared.warning(
+            "[TrafficEye][\(candidateId.uuidString.suffix(8))] No vehicle MMR data in API response (image crop likely too small or occluded)")
           let outcome = VerificationOutcome(
-            isMatch: false, description: "No vehicle detected", rejectReason: .apiError)
+            isMatch: false, description: "No vehicle detected", rejectReason: .noVehicleDetected)
           return Just(outcome).setFailureType(to: Error.self).eraseToAnyPublisher()
         }
 

--- a/thing-finder/Services/Pipeline/Verification/VerifierService+OCR.swift
+++ b/thing-finder/Services/Pipeline/Verification/VerifierService+OCR.swift
@@ -17,6 +17,7 @@ extension VerifierService {
     orientation: CGImagePropertyOrientation,
     store: CandidateStore
   ) {
+    TelemetryService.shared.markOCRUsed()
     DispatchQueue.global(qos: .userInitiated).async {
       // Re-map bbox to pixel rect (may be slightly outdated, acceptable)
       let (rect, _) = self.imgUtils.unscaledBoundingBoxes(

--- a/thing-finder/Services/Pipeline/Verification/VerifierService.swift
+++ b/thing-finder/Services/Pipeline/Verification/VerifierService.swift
@@ -151,6 +151,7 @@ public final class VerifierService: VerifierServiceProtocol {
       // For first-time verification show .waiting; for periodic re-verification keep current status to avoid extra speech.
       if cand.matchStatus == .unknown {
         store.update(id: cand.id) { $0.matchStatus = .waiting }
+        TelemetryService.shared.incrementCandidates()
       }
 
       let verifyStartTime = Date()
@@ -188,6 +189,21 @@ public final class VerifierService: VerifierServiceProtocol {
 
           // -------- Post-verification bookkeeping --------
           let latency = Date().timeIntervalSince(verifyStartTime)
+
+          let telemetryOutcome: String
+          if outcome.isMatch {
+            telemetryOutcome = "match"
+          } else if let reason = outcome.rejectReason, reason.isRetryable {
+            telemetryOutcome = "retry"
+          } else {
+            telemetryOutcome = "reject"
+          }
+          TelemetryService.shared.recordVerificationAttempt(
+            verifier: strategyName,
+            outcome: telemetryOutcome,
+            durationMs: Int(latency * 1000),
+            rejectReason: outcome.rejectReason?.rawValue
+          )
 
           DebugPublisher.shared.info(
             "[Verifier][\(cand.id.uuidString.suffix(8))] Result: strategy=\(strategyName), match=\(outcome.isMatch), view=\(String(describing: outcome.vehicleView)), score=\(String(describing: outcome.viewScore)), reason=\(String(describing: outcome.rejectReason?.rawValue)), latency=\(String(format: "%.3f", latency))s"

--- a/thing-finder/Services/Pipeline/Verification/VerifierService.swift
+++ b/thing-finder/Services/Pipeline/Verification/VerifierService.swift
@@ -235,6 +235,15 @@ public final class VerifierService: VerifierServiceProtocol {
           if outcome.isMatch {
             DebugPublisher.shared.info(
               "[Verifier][\(cand.id.uuidString.suffix(8))] Matched candidate")
+            let currentStatus = store[cand.id]?.matchStatus
+            if currentStatus == .lost || currentStatus == nil {
+              let reason = currentStatus == nil ? "removed" : "lost"
+              DebugPublisher.shared.warning(
+                "[Verifier][\(cand.id.uuidString.suffix(8))] Match returned but candidate was \(reason) during API call (latency \(String(format: "%.3f", latency))s)"
+              )
+              TelemetryService.shared.recordMatchDiscarded(
+                reason: reason, latencyMs: Int(latency * 1000))
+            }
             store.update(id: cand.id) {
               $0.detectedDescription = outcome.description
               $0.lastVerified = Date()

--- a/thing-finder/Services/Pipeline/Verification/VerifierService.swift
+++ b/thing-finder/Services/Pipeline/Verification/VerifierService.swift
@@ -243,6 +243,7 @@ public final class VerifierService: VerifierServiceProtocol {
               )
               TelemetryService.shared.recordMatchDiscarded(
                 reason: reason, latencyMs: Int(latency * 1000))
+              return
             }
             store.update(id: cand.id) {
               $0.detectedDescription = outcome.description

--- a/thing-finder/Services/Pipeline/Verification/VerifierService.swift
+++ b/thing-finder/Services/Pipeline/Verification/VerifierService.swift
@@ -151,7 +151,7 @@ public final class VerifierService: VerifierServiceProtocol {
       // For first-time verification show .waiting; for periodic re-verification keep current status to avoid extra speech.
       if cand.matchStatus == .unknown {
         store.update(id: cand.id) { $0.matchStatus = .waiting }
-        TelemetryService.shared.incrementCandidates()
+        TelemetryService.shared.incrementCandidates(id: cand.id)
       }
 
       let verifyStartTime = Date()

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -1,0 +1,161 @@
+/// TelemetryService
+/// -----------------
+/// Consent-gated analytics. Posts events to PostHog via a direct HTTP call —
+/// no SDK dependency required.
+///
+/// Usage:
+///   TelemetryService.shared.configure(settings: settings)
+///   TelemetryService.shared.recordSessionStarted(...)
+///
+/// All capture methods are no-ops when consent is .declined or .notAsked.
+
+import Foundation
+import UIKit
+
+public final class TelemetryService {
+
+  public static let shared = TelemetryService()
+  private init() {}
+
+  // MARK: - Configuration
+
+  private weak var settings: Settings?
+
+  public func configure(settings: Settings) {
+    self.settings = settings
+  }
+
+  // MARK: - Session State
+
+  private var sessionStartTime: Date?
+  private var sessionFound = false
+  private var totalCandidates = 0
+  private var usedOCR = false
+  private var firstDetectionEmitted = false
+
+  // MARK: - Public API
+
+  public func recordSessionStarted(
+    vehicleType: String,
+    hasPlate: Bool,
+    strategy: String,
+    searchMode: String
+  ) {
+    sessionStartTime = Date()
+    sessionFound = false
+    totalCandidates = 0
+    usedOCR = false
+    firstDetectionEmitted = false
+
+    capture(
+      "session_started",
+      properties: [
+        "vehicle_type": vehicleType,
+        "has_plate": hasPlate,
+        "strategy": strategy,
+        "search_mode": searchMode,
+      ])
+  }
+
+  /// Call once when the first vehicle detection occurs in a session.
+  public func recordFirstDetectionIfNeeded() {
+    guard !firstDetectionEmitted, let start = sessionStartTime else { return }
+    firstDetectionEmitted = true
+    let elapsed = Date().timeIntervalSince(start)
+    capture(
+      "first_detection",
+      properties: [
+        "time_to_first_detection_s": elapsed
+      ])
+  }
+
+  /// Call after each verifier API call completes.
+  public func recordVerificationAttempt(
+    verifier: String,
+    outcome: String,
+    durationMs: Int,
+    rejectReason: String?
+  ) {
+    var props: [String: Any] = [
+      "verifier": verifier,
+      "outcome": outcome,
+      "duration_ms": durationMs,
+    ]
+    if let reason = rejectReason {
+      props["reject_reason"] = reason
+    }
+    capture("verification_attempt", properties: props)
+  }
+
+  /// Call when the pipeline phase transitions to .found.
+  public func markSessionFound() {
+    sessionFound = true
+  }
+
+  /// Call each time a new candidate is created.
+  public func incrementCandidates() {
+    totalCandidates += 1
+  }
+
+  /// Call when OCR is first attempted in this session.
+  public func markOCRUsed() {
+    usedOCR = true
+  }
+
+  /// Call from ContentView.onDisappear to close out the session.
+  public func recordSessionEnded() {
+    let duration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+    capture(
+      "session_ended",
+      properties: [
+        "outcome": sessionFound ? "found" : "abandoned",
+        "duration_s": duration,
+        "total_candidates": totalCandidates,
+        "used_ocr": usedOCR,
+      ])
+    sessionStartTime = nil
+  }
+
+  // MARK: - Private
+
+  private var apiKey: String {
+    Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
+  }
+
+  private var distinctId: String {
+    let key = "telemetry_distinct_id"
+    if let stored = UserDefaults.standard.string(forKey: key) { return stored }
+    let newId = UUID().uuidString
+    UserDefaults.standard.set(newId, forKey: key)
+    return newId
+  }
+
+  private func capture(_ event: String, properties: [String: Any]) {
+    guard settings?.telemetryConsent == .accepted else { return }
+    let key = apiKey
+    guard !key.isEmpty else { return }
+
+    var payload: [String: Any] = [
+      "api_key": key,
+      "event": event,
+      "distinct_id": distinctId,
+      "properties": properties,
+    ]
+    payload["timestamp"] = ISO8601DateFormatter().string(from: Date())
+
+    guard let url = URL(string: "https://us.i.posthog.com/capture/"),
+      let body = try? JSONSerialization.data(withJSONObject: payload)
+    else { return }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    URLSession.shared.dataTask(with: request) { _, _, error in
+      if let error = error {
+        print("[Telemetry] Capture failed: \(error.localizedDescription)")
+      }
+    }.resume()
+  }
+}

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -153,14 +153,17 @@ public final class TelemetryService {
     var found = false
     var candidates = 0
     var ocr = false
+    var hadSession = false
     queue.sync {
       guard sessionStartTime != nil else { return }
+      hadSession = true
       duration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
       found = sessionFound
       candidates = totalCandidates
       ocr = usedOCR
       sessionStartTime = nil
     }
+    guard hadSession else { return }
     capture(
       "session_ended",
       properties: [

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -103,6 +103,17 @@ public final class TelemetryService {
     totalCandidates += 1
   }
 
+  /// Call when the verifier returns a match but the candidate was lost or
+  /// removed from the store before the result could be applied.
+  public func recordMatchDiscarded(reason: String, latencyMs: Int) {
+    capture(
+      "match_discarded",
+      properties: [
+        "reason": reason,
+        "latency_ms": latencyMs,
+      ])
+  }
+
   /// Call when OCR is first attempted in this session.
   public func markOCRUsed() {
     usedOCR = true

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -1,7 +1,6 @@
 /// TelemetryService
 /// -----------------
-/// Consent-gated analytics. Posts events to PostHog via a direct HTTP call —
-/// no SDK dependency required.
+/// Consent-gated analytics via the PostHog iOS SDK.
 ///
 /// Usage:
 ///   TelemetryService.shared.configure(settings: settings)
@@ -10,7 +9,7 @@
 /// All capture methods are no-ops when consent is .declined or .notAsked.
 
 import Foundation
-import UIKit
+import PostHog
 
 public final class TelemetryService {
 
@@ -23,6 +22,10 @@ public final class TelemetryService {
 
   public func configure(settings: Settings) {
     self.settings = settings
+    let key = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
+    guard !key.isEmpty else { return }
+    let config = PostHogConfig(apiKey: key)
+    PostHogSDK.shared.setup(config)
   }
 
   // MARK: - Session State
@@ -118,44 +121,8 @@ public final class TelemetryService {
 
   // MARK: - Private
 
-  private var apiKey: String {
-    Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
-  }
-
-  private var distinctId: String {
-    let key = "telemetry_distinct_id"
-    if let stored = UserDefaults.standard.string(forKey: key) { return stored }
-    let newId = UUID().uuidString
-    UserDefaults.standard.set(newId, forKey: key)
-    return newId
-  }
-
   private func capture(_ event: String, properties: [String: Any]) {
     guard settings?.telemetryConsent == .accepted else { return }
-    let key = apiKey
-    guard !key.isEmpty else { return }
-
-    var payload: [String: Any] = [
-      "api_key": key,
-      "event": event,
-      "distinct_id": distinctId,
-      "properties": properties,
-    ]
-    payload["timestamp"] = ISO8601DateFormatter().string(from: Date())
-
-    guard let url = URL(string: "https://us.i.posthog.com/capture/"),
-      let body = try? JSONSerialization.data(withJSONObject: payload)
-    else { return }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.httpBody = body
-
-    URLSession.shared.dataTask(with: request) { _, _, error in
-      if let error = error {
-        print("[Telemetry] Capture failed: \(error.localizedDescription)")
-      }
-    }.resume()
+    PostHogSDK.shared.capture(event, properties: properties)
   }
 }

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -3,10 +3,11 @@
 /// Consent-gated analytics via the PostHog iOS SDK.
 ///
 /// Usage:
-///   TelemetryService.shared.configure(settings: settings)
+///   TelemetryService.shared.setupSDK()
 ///   TelemetryService.shared.recordSessionStarted(...)
 ///
 /// All capture methods are no-ops when consent is .declined or .notAsked.
+/// Mutable state is protected by a serial dispatch queue for thread safety.
 
 import Foundation
 import PostHog
@@ -16,26 +17,37 @@ public final class TelemetryService {
   public static let shared = TelemetryService()
   private init() {}
 
+  // MARK: - Synchronisation
+
+  private let queue = DispatchQueue(label: "com.curb2car.telemetry", qos: .utility)
+
   // MARK: - Configuration
 
-  private weak var settings: Settings?
+  private var sdkConfigured = false
 
-  public func configure(settings: Settings) {
-    self.settings = settings
-    let key = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
-    guard !key.isEmpty else { return }
-    let config = PostHogConfig(apiKey: key)
-    config.captureScreenViews = false
-    config.enableSwizzling = false
-    config.surveys = false
-    PostHogSDK.shared.setup(config)
+  /// Set up the PostHog SDK once. Safe to call multiple times; only the first
+  /// call with accepted consent actually initialises the SDK.
+  public func setupSDKIfConsented() {
+    queue.sync {
+      guard !sdkConfigured else { return }
+      guard consentIsAccepted else { return }
+      let key = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
+      guard !key.isEmpty else { return }
+      let config = PostHogConfig(apiKey: key)
+      config.captureScreenViews = false
+      config.enableSwizzling = false
+      config.surveys = false
+      PostHogSDK.shared.setup(config)
+      sdkConfigured = true
+    }
   }
 
-  // MARK: - Session State
+  // MARK: - Session State (accessed only inside `queue`)
 
   private var sessionStartTime: Date?
   private var sessionFound = false
   private var totalCandidates = 0
+  private var seenCandidateIDs: Set<UUID> = []
   private var usedOCR = false
   private var firstDetectionEmitted = false
 
@@ -46,11 +58,16 @@ public final class TelemetryService {
     strategy: String,
     searchMode: String
   ) {
-    sessionStartTime = Date()
-    sessionFound = false
-    totalCandidates = 0
-    usedOCR = false
-    firstDetectionEmitted = false
+    setupSDKIfConsented()
+
+    queue.sync {
+      sessionStartTime = Date()
+      sessionFound = false
+      totalCandidates = 0
+      seenCandidateIDs = []
+      usedOCR = false
+      firstDetectionEmitted = false
+    }
 
     capture(
       "session_started",
@@ -63,9 +80,13 @@ public final class TelemetryService {
 
   /// Call once when the first vehicle detection occurs in a session.
   public func recordFirstDetectionIfNeeded() {
-    guard !firstDetectionEmitted, let start = sessionStartTime else { return }
-    firstDetectionEmitted = true
-    let elapsed = Date().timeIntervalSince(start)
+    var elapsed: TimeInterval?
+    queue.sync {
+      guard !firstDetectionEmitted, let start = sessionStartTime else { return }
+      firstDetectionEmitted = true
+      elapsed = Date().timeIntervalSince(start)
+    }
+    guard let elapsed else { return }
     capture(
       "first_detection",
       properties: [
@@ -93,12 +114,19 @@ public final class TelemetryService {
 
   /// Call when the pipeline phase transitions to .found.
   public func markSessionFound() {
-    sessionFound = true
+    queue.sync {
+      sessionFound = true
+    }
   }
 
-  /// Call each time a new candidate is created.
-  public func incrementCandidates() {
-    totalCandidates += 1
+  /// Call each time a candidate first enters verification.
+  /// Tracks unique candidates by ID so retries are not double-counted.
+  public func incrementCandidates(id: UUID) {
+    queue.sync {
+      if seenCandidateIDs.insert(id).inserted {
+        totalCandidates += 1
+      }
+    }
   }
 
   /// Call when the verifier returns a match but the candidate was lost or
@@ -114,27 +142,46 @@ public final class TelemetryService {
 
   /// Call when OCR is first attempted in this session.
   public func markOCRUsed() {
-    usedOCR = true
+    queue.sync {
+      usedOCR = true
+    }
   }
 
-  /// Call from ContentView.onDisappear to close out the session.
+  /// Call when the user explicitly ends a search session (e.g. navigates back).
   public func recordSessionEnded() {
-    let duration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+    var duration: TimeInterval = 0
+    var found = false
+    var candidates = 0
+    var ocr = false
+    queue.sync {
+      guard sessionStartTime != nil else { return }
+      duration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+      found = sessionFound
+      candidates = totalCandidates
+      ocr = usedOCR
+      sessionStartTime = nil
+    }
     capture(
       "session_ended",
       properties: [
-        "outcome": sessionFound ? "found" : "abandoned",
+        "outcome": found ? "found" : "abandoned",
         "duration_s": duration,
-        "total_candidates": totalCandidates,
-        "used_ocr": usedOCR,
+        "total_candidates": candidates,
+        "used_ocr": ocr,
       ])
-    sessionStartTime = nil
   }
 
   // MARK: - Private
 
+  /// Read consent directly from UserDefaults to avoid holding a weak/strong
+  /// reference to a Settings object that may be deallocated.
+  private var consentIsAccepted: Bool {
+    let raw = UserDefaults.standard.string(forKey: "telemetry_consent") ?? ""
+    return raw == TelemetryConsent.accepted.rawValue
+  }
+
   private func capture(_ event: String, properties: [String: Any]) {
-    guard settings?.telemetryConsent == .accepted else { return }
+    guard consentIsAccepted else { return }
     PostHogSDK.shared.capture(event, properties: properties)
   }
 }

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -42,7 +42,6 @@ public final class TelemetryService {
   // MARK: - Public API
 
   public func recordSessionStarted(
-    vehicleType: String,
     hasPlate: Bool,
     strategy: String,
     searchMode: String
@@ -56,7 +55,6 @@ public final class TelemetryService {
     capture(
       "session_started",
       properties: [
-        "vehicle_type": vehicleType,
         "has_plate": hasPlate,
         "strategy": strategy,
         "search_mode": searchMode,

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -25,6 +25,9 @@ public final class TelemetryService {
     let key = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String ?? ""
     guard !key.isEmpty else { return }
     let config = PostHogConfig(apiKey: key)
+    config.captureScreenViews = false
+    config.enableSwizzling = false
+    config.surveys = false
     PostHogSDK.shared.setup(config)
   }
 

--- a/thing-finder/Services/Telemetry/TelemetryService.swift
+++ b/thing-finder/Services/Telemetry/TelemetryService.swift
@@ -35,10 +35,25 @@ public final class TelemetryService {
       guard !key.isEmpty else { return }
       let config = PostHogConfig(apiKey: key)
       config.captureScreenViews = false
+      config.captureApplicationLifecycleEvents = false
       config.enableSwizzling = false
       config.surveys = false
       PostHogSDK.shared.setup(config)
+      PostHogSDK.shared.optIn()
       sdkConfigured = true
+    }
+  }
+
+  /// Call when consent changes. If the SDK has been set up, opts in or out
+  /// of PostHog data transmission accordingly.
+  public func updateConsentState() {
+    queue.sync {
+      guard sdkConfigured else { return }
+      if consentIsAccepted {
+        PostHogSDK.shared.optIn()
+      } else {
+        PostHogSDK.shared.optOut()
+      }
     }
   }
 

--- a/thing-finder/Utilities/MatchStatusSpeech.swift
+++ b/thing-finder/Utilities/MatchStatusSpeech.swift
@@ -115,6 +115,10 @@ enum MatchStatusSpeech {
       return String(
         localized: "Not sure yet, taking another shot",
         comment: "Speech: retry due to low confidence")
+    case .noVehicleDetected:
+      return String(
+        localized: "Can't make out the vehicle, retrying",
+        comment: "Speech: retry because TrafficEye found no vehicle in crop")
     case .apiError:
       return String(
         localized: "Detection error, retrying", comment: "Speech: retry due to API error")

--- a/thing-finder/Views/ContentView.swift
+++ b/thing-finder/Views/ContentView.swift
@@ -88,9 +88,9 @@ struct ContentView: View {
     .onRotate { _ in
       // Orientation changes are handled inside DetectorContainer
     }
-    .onDisappear {
-      TelemetryService.shared.recordSessionEnded()
-    }
+    // session_ended is recorded from InputView when isShowingCamera
+    // transitions back to false, so it fires only on explicit navigation
+    // back — not on tab switches or other temporary disappearances.
     .accessibilityAction(.magicTap) {
       playbackControl()
     }

--- a/thing-finder/Views/ContentView.swift
+++ b/thing-finder/Views/ContentView.swift
@@ -88,6 +88,9 @@ struct ContentView: View {
     .onRotate { _ in
       // Orientation changes are handled inside DetectorContainer
     }
+    .onDisappear {
+      TelemetryService.shared.recordSessionEnded()
+    }
     .accessibilityAction(.magicTap) {
       playbackControl()
     }

--- a/thing-finder/Views/InputView.swift
+++ b/thing-finder/Views/InputView.swift
@@ -129,7 +129,6 @@ struct InputView: View {
     let strategy: String = isParatransitMode ? "paratransit" : "hybrid"
     TelemetryService.shared.configure(settings: settings)
     TelemetryService.shared.recordSessionStarted(
-      vehicleType: selectedClasses.first ?? "unknown",
       hasPlate: parsed.plate != nil,
       strategy: strategy,
       searchMode: searchMode.rawValue

--- a/thing-finder/Views/InputView.swift
+++ b/thing-finder/Views/InputView.swift
@@ -127,7 +127,6 @@ struct InputView: View {
   private func recordSessionStarted() {
     let parsed = DescriptionParser.extractPlate(from: description)
     let strategy: String = isParatransitMode ? "paratransit" : "hybrid"
-    TelemetryService.shared.configure(settings: settings)
     TelemetryService.shared.recordSessionStarted(
       hasPlate: parsed.plate != nil,
       strategy: strategy,
@@ -434,6 +433,11 @@ struct InputView: View {
       }
       .onDisappear {
         hideKeyboard()
+      }
+      .onChange(of: isShowingCamera) { _, showing in
+        if !showing {
+          TelemetryService.shared.recordSessionEnded()
+        }
       }
       .navigationDestination(isPresented: $isShowingCamera) {
         ContentView(

--- a/thing-finder/Views/InputView.swift
+++ b/thing-finder/Views/InputView.swift
@@ -14,6 +14,7 @@ struct InputView: View {
   @AppStorage("InputView.searchHistory") private var searchHistoryData: String = "[]"
   @AppStorage("InputView.isParatransitMode") private var isParatransitMode = false
   @State private var shortcutNavigationState = ShortcutNavigationState.shared
+  @EnvironmentObject private var settings: Settings
 
   private var historyItems: [SearchHistoryItem] {
     (try? JSONDecoder().decode([SearchHistoryItem].self, from: Data(searchHistoryData.utf8))) ?? []
@@ -123,6 +124,18 @@ struct InputView: View {
         comment: "Placeholder: object description input")
   }
 
+  private func recordSessionStarted() {
+    let parsed = DescriptionParser.extractPlate(from: description)
+    let strategy: String = isParatransitMode ? "paratransit" : "hybrid"
+    TelemetryService.shared.configure(settings: settings)
+    TelemetryService.shared.recordSessionStarted(
+      vehicleType: selectedClasses.first ?? "unknown",
+      hasPlate: parsed.plate != nil,
+      strategy: strategy,
+      searchMode: searchMode.rawValue
+    )
+  }
+
   private func checkForShortcutNavigation() {
     if let carDesc = shortcutNavigationState.consumePendingDescription() {
       description = carDesc
@@ -130,6 +143,7 @@ struct InputView: View {
       showPlaceholder = false
       isParatransitMode = false
       saveToHistory(carDesc, mode: .uberFinder, paratransit: false)
+      recordSessionStarted()
       isShowingCamera = true
     }
 
@@ -139,6 +153,7 @@ struct InputView: View {
       showPlaceholder = false
       isParatransitMode = true
       saveToHistory(paratransitDesc, mode: .uberFinder, paratransit: true)
+      recordSessionStarted()
       isShowingCamera = true
     }
   }
@@ -239,6 +254,7 @@ struct InputView: View {
         Section {
           Button {
             saveToHistory(description, mode: searchMode, paratransit: isParatransitMode)
+            recordSessionStarted()
             isShowingCamera = true
           } label: {
             if searchMode == .uberFinder {
@@ -268,6 +284,7 @@ struct InputView: View {
                 showPlaceholder = false
                 saveToHistory(
                   item.description, mode: item.mode, paratransit: item.isParatransitMode)
+                recordSessionStarted()
                 isShowingCamera = true
               } label: {
                 HStack {
@@ -346,6 +363,7 @@ struct InputView: View {
                 showPlaceholder = false
                 saveToHistory(
                   item.description, mode: item.mode, paratransit: item.isParatransitMode)
+                recordSessionStarted()
                 isShowingCamera = true
               } label: {
                 HStack {

--- a/thing-finder/Views/SettingsView.swift
+++ b/thing-finder/Views/SettingsView.swift
@@ -266,6 +266,24 @@ struct SettingsView: View {
         //   }
         // }
 
+        // MARK: - Analytics
+        if settings.telemetryConsent != .notAsked {
+          Section(header: Text("Analytics")) {
+            Toggle(
+              "Share Anonymous Usage Data",
+              isOn: Binding(
+                get: { settings.telemetryConsent == .accepted },
+                set: { settings.telemetryConsent = $0 ? .accepted : .declined }
+              )
+            )
+            Text(
+              "Sends anonymous data about whether vehicles are found and where detection fails. No images, location, or license plate text is ever collected."
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+          }
+        }
+
         // MARK: - Developer Options
         Section(header: Text("Developer Options")) {
           Toggle("Debug Overlay", isOn: $settings.debugOverlayEnabled)

--- a/thing-finder/Views/TelemetryConsentView.swift
+++ b/thing-finder/Views/TelemetryConsentView.swift
@@ -83,3 +83,11 @@ private struct BulletRow: View {
     }
   }
 }
+
+#Preview {
+    TelemetryConsentView(
+        onAccept: {},
+        onDecline: {}
+    )
+}
+

--- a/thing-finder/Views/TelemetryConsentView.swift
+++ b/thing-finder/Views/TelemetryConsentView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct TelemetryConsentView: View {
+  let onAccept: () -> Void
+  let onDecline: () -> Void
+
+  var body: some View {
+    NavigationStack {
+      VStack(alignment: .leading, spacing: 20) {
+        Text("Help Improve CurbToCar")
+          .font(.title)
+          .bold()
+          .accessibilityAddTraits(.isHeader)
+
+        Text(
+          "We'd like to collect anonymous usage data to understand how well the app finds vehicles and where it falls short."
+        )
+        .font(.body)
+
+        Text("What we collect:")
+          .font(.headline)
+          .accessibilityAddTraits(.isHeader)
+
+        VStack(alignment: .leading, spacing: 8) {
+          BulletRow("Whether a vehicle was found and how long it took")
+          BulletRow("Which verification steps succeeded or failed")
+          BulletRow("Anonymous error counts per session")
+        }
+
+        Text("What we never collect:")
+          .font(.headline)
+          .accessibilityAddTraits(.isHeader)
+
+        VStack(alignment: .leading, spacing: 8) {
+          BulletRow("Images or video")
+          BulletRow("Your location")
+          BulletRow("License plate text")
+          BulletRow("Any personally identifiable information")
+        }
+
+        Text("You can change this at any time in Settings.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+
+        Spacer()
+
+        VStack(spacing: 12) {
+          Button {
+            onAccept()
+          } label: {
+            Text("Share Anonymous Data")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.borderedProminent)
+          .accessibilityLabel("Share anonymous usage data")
+          .accessibilityHint("Helps improve the app. No personal information is collected.")
+
+          Button {
+            onDecline()
+          } label: {
+            Text("No Thanks")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.bordered)
+          .accessibilityLabel("No thanks, don't share data")
+        }
+      }
+      .padding()
+      .navigationBarTitleDisplayMode(.inline)
+    }
+    .interactiveDismissDisabled(true)
+  }
+}
+
+private struct BulletRow: View {
+  let text: String
+  init(_ text: String) { self.text = text }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Text("•").accessibilityHidden(true)
+      Text(text).font(.body)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add PostHog telemetry with first-launch consent screen and opt-out, plus fixes for bugs identified by Devin Review.

**TelemetryService**: consent-gated singleton that captures events via PostHog iOS SDK. All methods are no-ops when consent is `.declined` or `.notAsked`.

**TelemetryConsentView**: full-screen modal shown once after the experimental disclaimer, with accessible Accept/Decline actions.

**Settings**: adds `TelemetryConsent` enum (`.notAsked`/`.accepted`/`.declined`) persisted via `@AppStorage`. Consent is preserved across settings resets.

**SettingsView**: adds "Share Anonymous Usage Data" toggle, visible only after the user has been asked.

**Events emitted**: `session_started`, `first_detection`, `verification_attempt`, `match_discarded`, `session_ended`. No images, location, plate text, or PII collected.

### Bug fixes (from Devin Review feedback)
1. **Thread safety** — Added serial `DispatchQueue` to protect all mutable state in `TelemetryService` (was accessed from main thread and camera background queue simultaneously)
2. **Consent-gated SDK setup** — PostHog SDK is now only initialized when consent is `.accepted`, not unconditionally at app launch
3. **No repeated `setup()` calls** — `sdkConfigured` flag prevents re-initializing PostHog SDK on every session start
4. **No weak Settings reference** — Reads consent directly from `UserDefaults` instead of holding a `weak var settings` that was immediately deallocated
5. **Unique candidate counting** — Tracks candidate IDs in a `Set<UUID>` so retries don't inflate `total_candidates`
6. **Session lifecycle** — Moved `session_ended` from `ContentView.onDisappear` (fires on tab switches) to `InputView.onChange(of: isShowingCamera)` (fires only on explicit navigation back)
7. **Guard-return in closure** — Fixed `recordSessionEnded()` where `guard return` inside `queue.sync` closure only exited the closure, not the function, causing bogus telemetry events
8. **Consent revocation** — Disabled `captureApplicationLifecycleEvents` to prevent PostHog auto-sending events that bypass our consent gate. Added `optOut()`/`optIn()` calls when the user toggles consent in Settings.
9. **Match discarded accuracy** — Added early return after recording `match_discarded` for lost/removed candidates so the match is truly discarded, not silently applied to a stale candidate

## Review & Testing Checklist for Human
- [ ] Verify telemetry consent flow: launch app → accept disclaimer → consent modal appears → accept/decline works correctly
- [ ] Verify no PostHog network requests are made before consent is accepted (check with a network proxy like Charles/Proxyman)
- [ ] Verify `session_ended` fires once when navigating back from camera, and does NOT fire on tab switches
- [ ] Verify toggling "Share Anonymous Usage Data" off in Settings actually stops all PostHog data transmission (optOut)
- [ ] Verify candidate count in `session_ended` event reflects unique candidates, not retry cycles

### Notes
- `POSTHOG_API_KEY` must be set in `Secrets.xcconfig` for telemetry to function
- The `TelemetryService` uses a serial `DispatchQueue` rather than Swift actors to avoid requiring `async` changes throughout the existing synchronous call sites

Link to Devin session: https://app.devin.ai/sessions/18ee2fd1901c4dba92d3210706989bc5
Requested by: @tagemehta
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tagemehta/car-navigator-swift/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
